### PR TITLE
Populate type dropdown with only enabled search types on the web interface

### DIFF
--- a/src/interface/web/index.html
+++ b/src/interface/web/index.html
@@ -93,12 +93,13 @@
                     .filter(type => data["content-type"].hasOwnProperty(type) && data["content-type"][type])
                     .map(type => `<option value="${type}">${type.slice(0,1).toUpperCase() + type.slice(1)}</option>`)
                     .join('');
+                })
+                .then(() => {
+                    // Set type field to search type passed in URL query parameter, if valid
+                    var type_via_url = new URLSearchParams(window.location.search).get("t");
+                    if (type_via_url && possible_search_types.includes(type_via_url))
+                        document.getElementById("type").value = type_via_url;
                 });
-
-            // Set type field to search type passed in URL query parameter, if valid
-            var type_via_url = new URLSearchParams(window.location.search).get("t");
-            if (type_via_url && type_via_url in possible_search_types)
-                document.getElementById("type").value = type_via_url;
         }
 
         window.onload = function () {
@@ -107,9 +108,8 @@
 
             // Fill query field with value passed in URL query parameters, if any.
             var query_via_url = new URLSearchParams(window.location.search).get("q");
-            if (query_via_url) {
+            if (query_via_url)
                 document.getElementById("query").value = query_via_url;
-            }
         }
     </script>
 

--- a/src/interface/web/index.html
+++ b/src/interface/web/index.html
@@ -82,9 +82,30 @@
             event.key === 'Enter' ? search(rerank=true) : search(rerank=false);
         }
 
-        // Fill search form with values passed in URL query parameters, if any.
+        function populate_type_dropdown() {
+            // Populate type dropdown field with enabled search types only
+            var possible_search_types = ["org", "markdown", "ledger", "music", "image"];
+            fetch("/config")
+                .then(response => response.json())
+                .then(data => {
+                    document.getElementById("type").innerHTML =
+                    possible_search_types
+                    .filter(type => data["content-type"].hasOwnProperty(type) && data["content-type"][type])
+                    .map(type => `<option value="${type}">${type.slice(0,1).toUpperCase() + type.slice(1)}</option>`)
+                    .join('');
+                });
+
+            // Set type field to search type passed in URL query parameter, if valid
+            var type_via_url = new URLSearchParams(window.location.search).get("t");
+            if (type_via_url && type_via_url in possible_search_types)
+                document.getElementById("type").value = type_via_url;
+        }
+
         window.onload = function () {
-            document.getElementById("type").value = new URLSearchParams(window.location.search).get("t") || "org";
+            // Dynamically populate type dropdown based on enabled search types and type passed as URL query parameter
+            populate_type_dropdown();
+
+            // Fill query field with value passed in URL query parameters, if any.
             var query_via_url = new URLSearchParams(window.location.search).get("q");
             if (query_via_url) {
                 document.getElementById("query").value = query_via_url;
@@ -98,16 +119,8 @@
         <!--Add Text Box To Enter Query, Trigger Incremental Search OnChange -->
         <input type="text" id="query" onkeyup=incremental_search(event) placeholder="What is the meaning of life?">
 
-        <!--Add Dropdown to Select Query Type.
-            Query Types can be: org, ledger, image, music, markdown.
-            Set Default type to org-->
-        <select id="type">
-            <option value="org">Org</option>
-            <option value="ledger">Ledger</option>
-            <option value="music">Music</option>
-            <option value="image">Image</option>
-            <option value="markdown">Markdown</option>
-        </select>
+        <!--Add Dropdown to Select Query Type -->
+        <select id="type"></select>
 
         <!--Add Button To Regenerate -->
         <button id="regenerate" onclick="regenerate()">Regenerate</button>

--- a/src/interface/web/index.html
+++ b/src/interface/web/index.html
@@ -85,7 +85,10 @@
         // Fill search form with values passed in URL query parameters, if any.
         window.onload = function () {
             document.getElementById("type").value = new URLSearchParams(window.location.search).get("t") || "org";
-            document.getElementById("query").value = new URLSearchParams(window.location.search).get("q") || "What is the meaning of life?";
+            var query_via_url = new URLSearchParams(window.location.search).get("q");
+            if (query_via_url) {
+                document.getElementById("query").value = query_via_url;
+            }
         }
     </script>
 

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -44,27 +44,11 @@ def cli(args=None):
 default_config = {
     'content-type':
     {
-        'org':
-        {
-            'compressed-jsonl': '.notes.jsonl.gz',
-            'embeddings-file': '.note_embeddings.pt'
-        },
-        'ledger':
-        {
-            'compressed-jsonl': '.transactions.jsonl.gz',
-            'embeddings-file': '.transaction_embeddings.pt'
-        },
-        'image':
-        {
-            'embeddings-file': '.image_embeddings.pt',
-            'batch-size': 50,
-            'use-xmp-metadata': 'no'
-        },
-        'music':
-        {
-            'compressed-jsonl': '.songs.jsonl.gz',
-            'embeddings-file': '.song_embeddings.pt'
-        },
+        'org': None,
+        'ledger': None,
+        'image': None,
+        'music': None,
+        'markdown': None,
     },
     'search-type':
     {

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -16,8 +16,6 @@ def cli(args=None):
 
     # Setup Argument Parser for the Commandline Interface
     parser = argparse.ArgumentParser(description="Expose API for Khoj")
-    parser.add_argument('--org-files', '-i', nargs='*', help="List of org-mode files to process")
-    parser.add_argument('--org-filter', type=str, default=None, help="Regex filter for org-mode files to process")
     parser.add_argument('--config-file', '-c', type=pathlib.Path, help="YAML file with user configuration")
     parser.add_argument('--regenerate', action='store_true', default=False, help="Regenerate model embeddings from source files. Default: false")
     parser.add_argument('--verbose', '-v', action='count', default=0, help="Show verbose conversion logs. Default: 0")
@@ -27,25 +25,18 @@ def cli(args=None):
 
     args = parser.parse_args(args)
 
-    if not (args.config_file or args.org_files):
-        print(f"Require at least 1 of --org-file, --org-filter or --config-file flags to be passed from commandline")
+    if not (args.config_file):
+        print(f"Need --config-file flag to be passed from commandline")
         exit(1)
 
-    # Config Priority: Cmd Args > Config File > Default Config
+    # Config Priority: Config File > Default Config
     args.config = default_config
     if args.config_file and resolve_absolute_path(args.config_file).exists():
         with open(get_absolute_path(args.config_file), 'r', encoding='utf-8') as config_file:
             config_from_file = yaml.safe_load(config_file)
             args.config = merge_dicts(priority_dict=config_from_file, default_dict=args.config)
-            args.config = FullConfig.parse_obj(args.config)
-    else:
-        args.config = FullConfig.parse_obj(args.config)
 
-    if args.org_files:
-        args.config.content_type.org.input_files = args.org_files
-
-    if args.org_filter:
-        args.config.content_type.org.input_filter = args.org_filter
+    args.config = FullConfig.parse_obj(args.config)
 
     return args
 

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -32,9 +32,9 @@ def get_from_dict(dictionary, *args):
 
 def merge_dicts(priority_dict, default_dict):
     merged_dict = priority_dict.copy()
-    for k, v in default_dict.items():
-        if k not in priority_dict:
-            merged_dict[k] = default_dict[k]
+    for key, _ in default_dict.items():
+        if key not in priority_dict:
+            merged_dict[key] = default_dict[key]
     return merged_dict
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,29 +42,3 @@ def test_cli_config_from_file():
     assert actual_args.config is not None
     assert actual_args.config.content_type.org.input_files == ['~/first_from_config.org', '~/second_from_config.org']
     assert actual_args.verbose == 3
-
-
-# ----------------------------------------------------------------------------------------------------
-def test_cli_config_from_cmd_args():
-    ""
-    # Act
-    actual_args = cli(['--org-files=first.org'])
-
-    # Assert
-    assert actual_args.org_files == ['first.org']
-    assert actual_args.config_file is None
-    assert actual_args.config is not None
-    assert actual_args.config.content_type.org.input_files == ['first.org']
-
-
-# ----------------------------------------------------------------------------------------------------
-def test_cli_config_from_cmd_args_override_config_file():
-    # Act
-    actual_args = cli(['--config-file=tests/data/config.yml',
-                       '--org-files=first.org'])
-
-    # Assert
-    assert actual_args.org_files == ['first.org']
-    assert actual_args.config_file == Path('tests/data/config.yml')
-    assert actual_args.config is not None
-    assert actual_args.config.content_type.org.input_files == ['first.org']


### PR DESCRIPTION
- Previously we were statically populating types dropdown field in the web interface with all available search types
- This change populates the type dropdown field with only search types that are enabled/configured
- It queries the `/config` backend API to see which of the available search types are configured