### PR TITLE
Do Not Prompt User to Set Search Type before Querying Khoj via Emacs

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -243,8 +243,6 @@
   (let* ((khoj-buffer-name (get-buffer-create khoj--buffer-name)))
     ;; set khoj search type to last used or based on current buffer
     (setq khoj--search-type (or khoj--search-type (khoj--buffer-name-to-search-type (buffer-name))))
-    ;; setup temporary keymap for khoj
-    (set-transient-map (khoj--search-keymap) t)
     ;; setup rerank to improve results once user idle for KHOJ--RERANK-AFTER-IDLE-TIME seconds
     (setq khoj--rerank-timer (run-with-idle-timer khoj--rerank-after-idle-time t 'khoj--incremental-search t))
     ;; switch to khoj results buffer
@@ -252,6 +250,8 @@
     ;; open and setup minibuffer for incremental search
     (minibuffer-with-setup-hook
         (lambda ()
+          ;; Add khoj keybindings for configuring search to minibuffer keybindings
+          (khoj--make-search-keymap minibuffer-local-map)
           ;; set current (mini-)buffer entered as khoj minibuffer
           ;; used to query khoj API only when user in khoj minibuffer
           (setq khoj--minibuffer-window (current-buffer))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -80,6 +80,16 @@
     (define-key kmap (kbd "C-x i") '(lambda () (interactive) (setq khoj--search-type "image")))
     kmap))
 
+(defvar khoj--keybindings-help-message
+  "
+     Set Search Type
+-------------------------
+C-x m  | markdown
+C-x o  | org-mode
+C-x l  | ledger/beancount
+C-x i  | images
+")
+
 (defun khoj--extract-entries-as-markdown (json-response query)
   "Convert json response from API to markdown entries"
   ;; remove leading (, ) or SPC from extracted entries string
@@ -252,6 +262,7 @@
         (lambda ()
           ;; Add khoj keybindings for configuring search to minibuffer keybindings
           (khoj--make-search-keymap minibuffer-local-map)
+          (message "%s" khoj--keybindings-help-message)
           ;; set current (mini-)buffer entered as khoj minibuffer
           ;; used to query khoj API only when user in khoj minibuffer
           (setq khoj--minibuffer-window (current-buffer))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -65,6 +65,9 @@
 (defconst khoj--query-prompt "🦅Khoj: "
   "Query prompt shown to user in the minibuffer.")
 
+(defconst khoj--buffer-name "*🦅Khoj*"
+  "Name of buffer to show results from Khoj.")
+
 (defvar khoj--search-type "org"
   "The type of content to perform search on.")
 
@@ -192,7 +195,7 @@
 ;; Incremental Search on Khoj
 (defun khoj--incremental-search (&optional rerank)
   (let* ((rerank-str (cond (rerank "true") (t "false")))
-         (buffer-name (get-buffer-create "*Khoj*"))
+         (khoj-buffer-name (get-buffer-create khoj--buffer-name))
          (query (minibuffer-contents-no-properties))
          (query-url (khoj--construct-api-query query khoj--search-type rerank-str)))
     ;; Query khoj API only when user in khoj minibuffer.
@@ -205,7 +208,7 @@
          query
          khoj--search-type
          query-url
-         buffer-name)))))
+         khoj-buffer-name)))))
 
 (defun delete-open-network-connections-to-khoj ()
   "Delete all network connections to khoj server"
@@ -237,7 +240,7 @@
 (defun khoj ()
   "Natural, Incremental Search for your personal notes, transactions and music using Khoj"
   (interactive)
-  (let* ((khoj-buffer-name (get-buffer-create "*Khoj*")))
+  (let* ((khoj-buffer-name (get-buffer-create khoj--buffer-name)))
     ;; set khoj search type to last used or based on current buffer
     (setq khoj--search-type (or khoj--search-type (khoj--buffer-name-to-search-type (buffer-name))))
     ;; setup temporary keymap for khoj
@@ -266,7 +269,7 @@
          (default-type (khoj--buffer-name-to-search-type (buffer-name)))
          (search-type (completing-read "Type: " '("org" "markdown" "ledger" "music" "image") nil t default-type))
          (query-url (khoj--construct-api-query query search-type rerank))
-         (buffer-name (get-buffer-create (format "*Khoj (q:%s t:%s)*" query search-type))))
+         (buffer-name (get-buffer-create (format "*%s (q:%s t:%s)*" khoj--buffer-name query search-type))))
     (khoj--query-api-and-render-results
         query
         search-type

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -153,7 +153,7 @@
   (let ((file-extension (file-name-extension buffer-name)))
     (cond
      ((equal buffer-name "Music.org") "music")
-     ((equal file-extension "bean") "ledger")
+     ((or (equal file-extension "bean") (equal file-extension "beancount")) "ledger")
      ((equal file-extension "org") "org")
      ((or (equal file-extension "markdown") (equal file-extension "md")) "markdown")
      (t "org"))))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -71,14 +71,14 @@
 (defvar khoj--search-type "org"
   "The type of content to perform search on.")
 
-(defvar khoj--search-keymap
-  (let ((kmap (make-sparse-keymap)))
+(defun khoj--make-search-keymap (&optional existing-keymap)
+  "Setup keymap to configure Khoj search"
+  (let ((kmap (or existing-keymap (make-sparse-keymap))))
     (define-key kmap (kbd "C-x m") '(lambda () (interactive) (setq khoj--search-type "markdown")))
     (define-key kmap (kbd "C-x o") '(lambda () (interactive) (setq khoj--search-type "org")))
     (define-key kmap (kbd "C-x l") '(lambda () (interactive) (setq khoj--search-type "ledger")))
     (define-key kmap (kbd "C-x i") '(lambda () (interactive) (setq khoj--search-type "image")))
-    kmap)
-  "Keymap to configure Khoj search")
+    kmap))
 
 (defun khoj--extract-entries-as-markdown (json-response query)
   "Convert json response from API to markdown entries"
@@ -244,7 +244,7 @@
     ;; set khoj search type to last used or based on current buffer
     (setq khoj--search-type (or khoj--search-type (khoj--buffer-name-to-search-type (buffer-name))))
     ;; setup temporary keymap for khoj
-    (set-transient-map khoj--search-keymap t)
+    (set-transient-map (khoj--search-keymap) t)
     ;; setup rerank to improve results once user idle for KHOJ--RERANK-AFTER-IDLE-TIME seconds
     (setq khoj--rerank-timer (run-with-idle-timer khoj--rerank-after-idle-time t 'khoj--incremental-search t))
     ;; switch to khoj results buffer

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -208,12 +208,15 @@ C-x i  | images
          (khoj-buffer-name (get-buffer-create khoj--buffer-name))
          (query (minibuffer-contents-no-properties))
          (query-url (khoj--construct-api-query query khoj--search-type rerank-str)))
-    ;; Query khoj API only when user in khoj minibuffer.
-    ;; Prevents querying during recursive edits or with contents of other buffers user may jump to
-    (when (and (active-minibuffer-window) (equal (current-buffer) khoj--minibuffer-window))
+    ;; Query khoj API only when user in khoj minibuffer and non-empty query
+    ;; Prevents querying if
+    ;;   1. user hasn't started typing query
+    ;;   2. during recursive edits
+    ;;   3. with contents of other buffers user may jump to
+    (when (and (not (equal query "")) (active-minibuffer-window) (equal (current-buffer) khoj--minibuffer-window))
       (progn
         (when rerank
-          (message "[Khoj]: Rerank Results"))
+          (message "Khoj: Rerank Results"))
         (khoj--query-api-and-render-results
          query
          khoj--search-type

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -71,16 +71,7 @@
 (defvar khoj--search-type "org"
   "The type of content to perform search on.")
 
-(defun khoj--make-search-keymap (&optional existing-keymap)
-  "Setup keymap to configure Khoj search"
-  (let ((kmap (or existing-keymap (make-sparse-keymap))))
-    (define-key kmap (kbd "C-x m") '(lambda () (interactive) (setq khoj--search-type "markdown")))
-    (define-key kmap (kbd "C-x o") '(lambda () (interactive) (setq khoj--search-type "org")))
-    (define-key kmap (kbd "C-x l") '(lambda () (interactive) (setq khoj--search-type "ledger")))
-    (define-key kmap (kbd "C-x i") '(lambda () (interactive) (setq khoj--search-type "image")))
-    kmap))
-
-(defvar khoj--keybindings-help-message
+(defvar khoj--keybindings-info-message
   "
      Set Search Type
 -------------------------
@@ -89,6 +80,28 @@ C-x o  | org-mode
 C-x l  | ledger/beancount
 C-x i  | images
 ")
+(defun khoj--search-markdown (interactive) (setq khoj--search-type "markdown"))
+(defun khoj--search-org (interactive) (setq khoj--search-type "org"))
+(defun khoj--search-ledger (interactive) (setq khoj--search-type "ledger"))
+(defun khoj--search-images (interactive) (setq khoj--search-type "image"))
+(defun khoj--make-search-keymap (&optional existing-keymap)
+  "Setup keymap to configure Khoj search"
+  (let ((kmap (or existing-keymap (make-sparse-keymap))))
+    (define-key kmap (kbd "C-x m") #'khoj--search-markdown)
+    (define-key kmap (kbd "C-x o") #'khoj--search-org)
+    (define-key kmap (kbd "C-x l") #'khoj--search-ledger)
+    (define-key kmap (kbd "C-x i") #'khoj--search-images)
+    kmap))
+(defun khoj--display-keybinding-info ()
+  "Display information on keybindings to customize khoj search.
+Use `which-key` if available, else display simple message in echo area"
+  (if (fboundp 'which-key--create-buffer-and-show)
+      (which-key--create-buffer-and-show
+       (kbd "C-x")
+       (symbolp (khoj--make-search-keymap))
+       '(lambda (binding) (string-prefix-p "khoj--" (cdr binding)))
+       "Khoj Bindings")
+    (message "%s" khoj--keybindings-info-message)))
 
 (defun khoj--extract-entries-as-markdown (json-response query)
   "Convert json response from API to markdown entries"
@@ -265,7 +278,8 @@ C-x i  | images
         (lambda ()
           ;; Add khoj keybindings for configuring search to minibuffer keybindings
           (khoj--make-search-keymap minibuffer-local-map)
-          (message "%s" khoj--keybindings-help-message)
+          ;; Display information on keybindings to customize khoj search
+          (khoj--display-keybinding-info)
           ;; set current (mini-)buffer entered as khoj minibuffer
           ;; used to query khoj API only when user in khoj minibuffer
           (setq khoj--minibuffer-window (current-buffer))


### PR DESCRIPTION
### Why
- Reduce time from intent to results by using reasonable defaults
- Make interactions smoother, more intuitive
- Users expect to start querying immediately. The prompt to enter search type creates unnecessary friction

### How
- By default, search using last searched content type
- Allow user to change search type, while querying, by using keyboard shortcuts
- For reference, display keyboard shortcuts to set search-type when user initiates (incremental) search