### PR TITLE
Improve Usage of User Customizable Variables in Emacs Interface

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -36,22 +36,22 @@
 (require 'url)
 (require 'json)
 
-(defcustom khoj--server-url "http://localhost:8000"
+(defcustom khoj-server-url "http://localhost:8000"
   "Location of Khoj API server."
   :group 'khoj
   :type 'string)
 
-(defcustom khoj--image-width 156
+(defcustom khoj-image-width 156
   "Width of rendered images returned by Khoj."
   :group 'khoj
   :type 'integer)
 
-(defcustom khoj--rerank-after-idle-time 1.0
+(defcustom khoj-rerank-after-idle-time 1.0
   "Idle time (in seconds) to trigger cross-encoder to rerank incremental search results."
   :group 'khoj
   :type 'float)
 
-(defcustom khoj--results-count 5
+(defcustom khoj-results-count 5
   "Number of results to get from Khoj API for each query."
   :group 'khoj
   :type 'integer)
@@ -173,9 +173,9 @@ Use `which-key` if available, else display simple message in echo area"
                              (cdr (assoc 'score args))
                              (cdr (assoc 'metadata_score args))
                              (cdr (assoc 'image_score args))
-                             khoj--server-url
+                             khoj-server-url
                              (cdr (assoc 'entry args))
-                             khoj--server-url
+                             khoj-server-url
                              (cdr (assoc 'entry args))
                              (random 10000)))
              json-response)))))
@@ -207,7 +207,7 @@ Use `which-key` if available, else display simple message in echo area"
 
 (defun khoj--get-enabled-content-types ()
   "Get content types enabled for search from API"
-  (let ((config-url (format "%s/config/data" khoj--server-url)))
+  (let ((config-url (format "%s/config/data" khoj-server-url)))
     (with-temp-buffer
       (erase-buffer)
       (url-insert-file-contents config-url)
@@ -222,9 +222,8 @@ Use `which-key` if available, else display simple message in echo area"
 
 (defun khoj--construct-api-query (query search-type &optional rerank)
   (let ((rerank (or rerank "false"))
-        (results-count (or khoj--results-count 5))
         (encoded-query (url-hexify-string query)))
-    (format "%s/search?q=%s&t=%s&r=%s&n=%s" khoj--server-url encoded-query search-type rerank results-count)))
+    (format "%s/search?q=%s&t=%s&r=%s&n=%s" khoj-server-url encoded-query search-type rerank khoj-results-count)))
 
 (defun khoj--query-api-and-render-results (query search-type query-url buffer-name)
   ;; get json response from api
@@ -279,7 +278,7 @@ Use `which-key` if available, else display simple message in echo area"
   "Delete all network connections to khoj server"
   (dolist (proc (process-list))
     (let ((proc-buf (buffer-name (process-buffer proc)))
-          (khoj-network-proc-buf (string-join (split-string khoj--server-url "://") " ")))
+          (khoj-network-proc-buf (string-join (split-string khoj-server-url "://") " ")))
       (when (string-match (format "%s" khoj-network-proc-buf) proc-buf)
         (delete-process proc)))))
 
@@ -309,8 +308,8 @@ Use `which-key` if available, else display simple message in echo area"
   (let* ((khoj-buffer-name (get-buffer-create khoj--buffer-name)))
     ;; set khoj search type to last used or based on current buffer
     (setq khoj--search-type (or khoj--search-type (khoj--buffer-name-to-search-type (buffer-name))))
-    ;; setup rerank to improve results once user idle for KHOJ--RERANK-AFTER-IDLE-TIME seconds
-    (setq khoj--rerank-timer (run-with-idle-timer khoj--rerank-after-idle-time t 'khoj--incremental-search t))
+    ;; setup rerank to improve results once user idle for KHOJ-RERANK-AFTER-IDLE-TIME seconds
+    (setq khoj--rerank-timer (run-with-idle-timer khoj-rerank-after-idle-time t 'khoj--incremental-search t))
     ;; switch to khoj results buffer
     (switch-to-buffer khoj-buffer-name)
     ;; open and setup minibuffer for incremental search

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -46,6 +46,11 @@
   :group 'khoj
   :type 'integer)
 
+(defcustom khoj-image-height 156
+  "Height of rendered images returned by Khoj."
+  :group 'khoj
+  :type 'integer)
+
 (defcustom khoj-rerank-after-idle-time 2.0
   "Idle time (in seconds) to trigger cross-encoder to rerank incremental search results."
   :group 'khoj
@@ -169,7 +174,7 @@ Use `which-key` if available, else display simple message in echo area"
             query
             (mapcar
              (lambda (args) (format
-                             "\n\n<h2>Score: %s Meta: %s Image: %s</h2>\n\n<a href=\"%s%s\">\n<img src=\"%s%s?%s\" width=100 height=100>\n</a>"
+                             "\n\n<h2>Score: %s Meta: %s Image: %s</h2>\n\n<a href=\"%s%s\">\n<img src=\"%s%s?%s\" width=%s height=%s>\n</a>"
                              (cdr (assoc 'score args))
                              (cdr (assoc 'metadata_score args))
                              (cdr (assoc 'image_score args))
@@ -177,7 +182,9 @@ Use `which-key` if available, else display simple message in echo area"
                              (cdr (assoc 'entry args))
                              khoj-server-url
                              (cdr (assoc 'entry args))
-                             (random 10000)))
+                             (random 10000)
+                             khoj-image-width
+                             khoj-image-height))
              json-response)))))
 
 (defun khoj--extract-entries-as-ledger (json-response query)

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -46,7 +46,7 @@
   :group 'khoj
   :type 'integer)
 
-(defcustom khoj-rerank-after-idle-time 1.0
+(defcustom khoj-rerank-after-idle-time 2.0
   "Idle time (in seconds) to trigger cross-encoder to rerank incremental search results."
   :group 'khoj
   :type 'float)

--- a/src/main.py
+++ b/src/main.py
@@ -69,10 +69,12 @@ def search(q: str, n: Optional[int] = 5, t: Optional[SearchType] = None, r: Opti
         print(f'No query param (q) passed in API call to initiate search')
         return {}
 
+    # initialize variables
     device = torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
     user_query = q
     results_count = n
     results = {}
+    query_start, query_end, collate_start, collate_end = None, None, None, None
 
     if (t == SearchType.Org or t == None) and model.orgmode_search:
         # query org-mode notes
@@ -136,8 +138,10 @@ def search(q: str, n: Optional[int] = 5, t: Optional[SearchType] = None, r: Opti
         collate_end = time.time()
 
     if verbose > 1:
-        print(f"Query took {query_end - query_start:.3f} seconds")
-        print(f"Collating results took {collate_end - collate_start:.3f} seconds")
+        if query_start and query_end:
+            print(f"Query took {query_end - query_start:.3f} seconds")
+        if collate_start and collate_end:
+            print(f"Collating results took {collate_end - collate_start:.3f} seconds")
 
     return results
 


### PR DESCRIPTION
- Follow standard single-hyphen in names of user customizable variables
- Set size of images results rendered in Emacs using user customizable variables
- Wait 2s, by default, before initiating re-ranking of results in Emacs interface

- Fix query timing variables from being referenced before assignment on backend