### PR TITLE
Improve Configure Screen on Desktop Interface

### DIFF
--- a/src/interface/desktop/configure_screen.py
+++ b/src/interface/desktop/configure_screen.py
@@ -37,6 +37,7 @@ class ConfigureScreen(QtWidgets.QDialog):
         # Initialize Configure Window
         self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
         self.setWindowTitle("Khoj - Configure")
+        self.setFixedWidth(600)
 
         # Initialize Configure Window Layout
         layout = QtWidgets.QVBoxLayout()

--- a/src/interface/desktop/configure_screen.py
+++ b/src/interface/desktop/configure_screen.py
@@ -173,7 +173,7 @@ class ConfigureScreen(QtWidgets.QDialog):
                         self.new_config['processor'][child.processor_type.value] = merge_dicts(current_processor_config, default_processor_config)
                 elif isinstance(child, LabelledTextField) and child.processor_type in self.new_config['processor']:
                     if child.processor_type == ProcessorType.Conversation:
-                        self.new_config['processor'][child.processor_type.value]['openai-api-key'] = child.input_field.text() if child.input_field.text() != '' else None
+                        self.new_config['processor'][child.processor_type.value]['openai-api-key'] = child.input_field.toPlainText() if child.input_field.toPlainText() != '' else None
 
     def save_settings_to_file(self) -> bool:
         # Validate config before writing to file

--- a/src/interface/desktop/configure_screen.py
+++ b/src/interface/desktop/configure_screen.py
@@ -1,5 +1,7 @@
 # Standard Packages
 from pathlib import Path
+from copy import deepcopy
+
 
 # External Packages
 from PyQt6 import QtWidgets
@@ -31,7 +33,7 @@ class ConfigureScreen(QtWidgets.QDialog):
         if resolve_absolute_path(self.config_file).exists():
             self.current_config = yaml_utils.load_config_from_file(self.config_file)
         else:
-            self.current_config = constants.default_config
+            self.current_config = deepcopy(constants.default_config)
         self.new_config = self.current_config
 
         # Initialize Configure Window

--- a/src/interface/desktop/configure_screen.py
+++ b/src/interface/desktop/configure_screen.py
@@ -36,7 +36,7 @@ class ConfigureScreen(QtWidgets.QDialog):
 
         # Initialize Configure Window
         self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
-        self.setWindowTitle("Khoj - Configure")
+        self.setWindowTitle("Configure - Khoj")
         self.setFixedWidth(600)
 
         # Initialize Configure Window Layout

--- a/src/interface/desktop/file_browser.py
+++ b/src/interface/desktop/file_browser.py
@@ -23,7 +23,7 @@ class FileBrowser(QtWidgets.QWidget):
         layout.addWidget(self.label)
         
         self.lineEdit = QtWidgets.QPlainTextEdit(self)
-        self.lineEdit.setFixedWidth(180)
+        self.lineEdit.setFixedWidth(330)
         self.setFiles(default_files)
         self.lineEdit.setFixedHeight(min(7+20*len(self.lineEdit.toPlainText().split('\n')),90))
         self.lineEdit.textChanged.connect(self.updateFieldHeight)

--- a/src/interface/desktop/file_browser.py
+++ b/src/interface/desktop/file_browser.py
@@ -19,12 +19,14 @@ class FileBrowser(QtWidgets.QWidget):
         self.label = QtWidgets.QLabel()
         self.label.setText(title)
         self.label.setFixedWidth(95)
+        self.label.setWordWrap(True)
         layout.addWidget(self.label)
         
-        self.lineEdit = QtWidgets.QLineEdit(self)
+        self.lineEdit = QtWidgets.QPlainTextEdit(self)
         self.lineEdit.setFixedWidth(180)
         self.setFiles(default_files)
-        
+        self.lineEdit.setFixedHeight(min(7+20*len(self.lineEdit.toPlainText().split('\n')),90))
+        self.lineEdit.textChanged.connect(self.updateFieldHeight)
         layout.addWidget(self.lineEdit)
         
         self.button = QtWidgets.QPushButton('Select')
@@ -60,12 +62,15 @@ class FileBrowser(QtWidgets.QWidget):
         if not self.filepaths or len(self.filepaths) == 0:
             return
         elif len(self.filepaths) == 1:
-            self.lineEdit.setText(self.filepaths[0])
+            self.lineEdit.setPlainText(self.filepaths[0])
         else:
-            self.lineEdit.setText(",".join(self.filepaths))    
+            self.lineEdit.setPlainText("\n".join(self.filepaths))
 
     def getPaths(self):
-        if self.lineEdit.text() == '':
+        if self.lineEdit.toPlainText() == '':
             return []
         else:
-            return self.lineEdit.text().split(',')
+            return self.lineEdit.toPlainText().split('\n')
+
+    def updateFieldHeight(self):
+        self.lineEdit.setFixedHeight(min(7+20*len(self.lineEdit.toPlainText().split('\n')),90))

--- a/src/interface/desktop/file_browser.py
+++ b/src/interface/desktop/file_browser.py
@@ -27,7 +27,7 @@ class FileBrowser(QtWidgets.QWidget):
         
         layout.addWidget(self.lineEdit)
         
-        self.button = QtWidgets.QPushButton('Add')
+        self.button = QtWidgets.QPushButton('Select')
         self.button.clicked.connect(self.storeFilesSelectedInFileDialog)
         layout.addWidget(self.button)
         layout.addStretch()

--- a/src/interface/desktop/labelled_text_field.py
+++ b/src/interface/desktop/labelled_text_field.py
@@ -1,0 +1,25 @@
+# External Packages
+from PyQt6 import QtWidgets
+
+# Internal Packages
+from src.utils.config import ProcessorType
+
+
+class LabelledTextField(QtWidgets.QWidget):
+    def __init__(self, title, processor_type: ProcessorType=None, default_value: str=None):
+        QtWidgets.QWidget.__init__(self)
+        layout = QtWidgets.QHBoxLayout()
+        self.setLayout(layout)
+        self.processor_type = processor_type
+
+        self.label = QtWidgets.QLabel()
+        self.label.setText(title)
+        self.label.setFixedWidth(95)
+        layout.addWidget(self.label)
+
+        self.input_field = QtWidgets.QLineEdit(self)
+        self.input_field.setFixedWidth(250)
+        self.input_field.setText(default_value)
+
+        layout.addWidget(self.input_field)
+        layout.addStretch()

--- a/src/interface/desktop/labelled_text_field.py
+++ b/src/interface/desktop/labelled_text_field.py
@@ -15,10 +15,12 @@ class LabelledTextField(QtWidgets.QWidget):
         self.label = QtWidgets.QLabel()
         self.label.setText(title)
         self.label.setFixedWidth(95)
+        self.label.setWordWrap(True)
         layout.addWidget(self.label)
 
-        self.input_field = QtWidgets.QLineEdit(self)
+        self.input_field = QtWidgets.QTextEdit(self)
         self.input_field.setFixedWidth(250)
+        self.input_field.setFixedHeight(27)
         self.input_field.setText(default_value)
 
         layout.addWidget(self.input_field)

--- a/src/interface/desktop/labelled_text_field.py
+++ b/src/interface/desktop/labelled_text_field.py
@@ -19,7 +19,7 @@ class LabelledTextField(QtWidgets.QWidget):
         layout.addWidget(self.label)
 
         self.input_field = QtWidgets.QTextEdit(self)
-        self.input_field.setFixedWidth(250)
+        self.input_field.setFixedWidth(410)
         self.input_field.setFixedHeight(27)
         self.input_field.setText(default_value)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 # Standard Packages
+import signal
 import sys
 
 # External Packages
@@ -6,7 +7,7 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from PyQt6 import QtWidgets
-from PyQt6.QtCore import QThread
+from PyQt6.QtCore import QThread, QTimer
 
 # Internal Packages
 from src.configure import configure_server
@@ -49,10 +50,22 @@ def run():
         if args.config is None:
             configure_screen.show()
 
+        # Setup Signal Handlers
+        signal.signal(signal.SIGINT, sigint_handler)
+        # Invoke python Interpreter every 500ms to handle signals
+        timer = QTimer()
+        timer.start(500)
+        timer.timeout.connect(lambda: None)
+
         # Start Application
         server.start()
         gui.aboutToQuit.connect(server.terminate)
         gui.exec()
+
+
+def sigint_handler(*args):
+    print("\nShutting down Khoj...")
+    QtWidgets.QApplication.quit()
 
 
 def set_state(args):


### PR DESCRIPTION
- 6e159e6: Reload settings in separate thread to not freeze Config Screen
- 32ac1ea: Allow user to quit application from the terminal via SIGINT
- 927547d: Update Title of Configure Screen to follow "[Screen] - App" pattern
- 43301d4: Increase Width of Configure Screen
- 9baea9c: Let Input Fields Wrap. Adjust Height based on Text in Field
- b7b9611: Rename FileBrowser Button Text to "Select" instead of "Add"
  - Reduce user confusion on how to add multiple files per content type
- a1c58a9: Create a reusable class for the Conversation Label+Text Input Field