### PR TITLE
Update GUI to Handle No System Tray on Linux

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 # Standard Packages
+from platform import system
 import signal
 import sys
 
@@ -37,17 +38,23 @@ def run():
     else:
         # Setup GUI
         gui = QtWidgets.QApplication([])
-        gui.setQuitOnLastWindowClosed(False)
         configure_screen = ConfigureScreen(args.config_file)
-        tray = create_system_tray(gui, configure_screen)
-        tray.show()
+
+        # System tray is only available on Windows, MacOS.
+        # On Linux (Gnome) the System tray is not supported.
+        # Since only the Configure Window is available
+        # Quitting it should quit the application
+        if system() in ['Windows', 'Darwin']:
+            gui.setQuitOnLastWindowClosed(False)
+            tray = create_system_tray(gui, configure_screen)
+            tray.show()
 
         # Setup Server
         configure_server(args, required=False)
         server = ServerThread(app, args.host, args.port, args.socket)
 
-        # Trigger First Run Experience, if required
-        if args.config is None:
+        # Show Configure Screen on Linux (etc.) or First Run Experience
+        if args.config is None or system() not in ['Windows', 'Darwin']:
             configure_screen.show()
 
         # Setup Signal Handlers


### PR DESCRIPTION
- What
  - Add Button to Open Search Interface on Web in "Configure Screen"
    - Provides GUI affordance for opening search interface to Linux users
  - On Linux
    - Show Configure Screen, even if not first run experience
    - Do no show system tray on Linux
    - Quit app on closing Configure Screen
  - On Windows, Mac
    - Show Configure screen only if first run experience
    - Show system tray always
    - Do not quit app on closing Configure Screen
- Why
  - Configure screen is the only GUI element on Linux. So closing it
    should close the application
  - On Windows, Mac the system tray exists, so app should not be closed
    on closing configure screen