### PR TITLE
Fix khoj.el reaching for a URL that doesn't exist

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -226,7 +226,7 @@ Use `which-key` if available, else display simple message in echo area"
 
 (defun khoj--get-enabled-content-types ()
   "Get content types enabled for search from API."
-  (let ((config-url (format "%s/api/config/data" khoj-server-url))
+  (let ((config-url (format "%s/config/data" khoj-server-url))
         (url-request-method "GET"))
     (with-temp-buffer
       (erase-buffer)
@@ -244,7 +244,7 @@ Use `which-key` if available, else display simple message in echo area"
   "Construct API Query from QUERY, SEARCH-TYPE and (optional) RERANK params."
   (let ((rerank (or rerank "false"))
         (encoded-query (url-hexify-string query)))
-    (format "%s/api/search?q=%s&t=%s&r=%s&n=%s" khoj-server-url encoded-query search-type rerank khoj-results-count)))
+    (format "%s/search?q=%s&t=%s&r=%s&n=%s" khoj-server-url encoded-query search-type rerank khoj-results-count)))
 
 (defun khoj--query-api-and-render-results (query search-type query-url buffer-name)
   "Query Khoj API using QUERY, SEARCH-TYPE, QUERY-URL.


### PR DESCRIPTION
since /api doesn't exist I just changed the urls the emacs search grabs and I have tested it