### PR TITLE
Add Chat page to the Khoj Web Interface

### DIFF
--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -15,12 +15,6 @@
             window.history.pushState({}, "", url.href);
         }
 
-        function setQueryFieldInUrl(query) {
-            let url = new URL(window.location.href);
-            url.searchParams.set("q", query);
-            window.history.pushState({}, "", url.href);
-        }
-
         function formatDate(date) {
             // Format date in HH:MM, DD MMM YYYY format
             let time_string = date.toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit', hour12: false });
@@ -30,7 +24,7 @@
 
         function renderMessage(message, by, dt=null) {
             let message_time = formatDate(dt ?? new Date());
-            let by_name =  by == "khoj" ? "🦅 Khoj" : "😲 You";
+            let by_name =  by == "khoj" ? "🦅 Khoj" : "🤔 You";
             // Generate HTML for Chat Message and Append to Chat Body
             document.getElementById("chat-body").innerHTML += `
                 <div data-meta="${by_name} at ${message_time}" class="chat-message ${by}">
@@ -50,9 +44,6 @@
             // Short circuit on empty query
             if (query.length === 0)
                 return;
-
-            // Set query field in url query param
-            setQueryFieldInUrl(query);
 
             // Add message by user to chat body
             renderMessage(query, "you");

--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -101,13 +101,91 @@
 
         <!-- Chat Footer -->
         <div id="chat-footer">
-            <input type="text" id="chat-input" onkeyup=incrementalChat(event) autofocus="autofocus" placeholder="What is the meaning of life?">
+            <input type="text" id="chat-input" class="option" onkeyup=incrementalChat(event) autofocus="autofocus" placeholder="What is the meaning of life?">
 
             <!--Select Chat Type from: Chat, Summarize -->
-            <select id="chat-type" onchange="setTypeFieldInUrl(this)">
+            <select id="chat-type" class="option" onchange="setTypeFieldInUrl(this)">
                 <option value="chat">Chat</option>
                 <option value="summarize">Summarize</option>
             </select>
         </div>
     </body>
+
+    <style>
+        html, body {
+            height: 100%;
+            width: 100%;
+            padding: 0px;
+            margin: 0px;
+        }
+        body {
+            display: grid;
+            background: #f8fafc;
+            color: #475569;
+            text-align: center;
+            font-family: roboto, karma, segoe ui, sans-serif;
+            font-size: 20px;
+            font-weight: 300;
+            line-height: 1.5em;
+        }
+        body > * {
+            padding: 10px;
+            margin: 10px;
+        }
+        h1 {
+            font-weight: 200;
+            color: #017eff;
+        }
+
+        #chat-body {
+            font-size: medium;
+            margin: 0px;
+            line-height: 20px;
+            overflow-y: scroll;
+        }
+
+        #chat-footer {
+            padding: 0;
+            display: grid;
+            grid-template-columns: minmax(70px, 85%) auto;
+            grid-column-gap: 10px;
+            grid-row-gap: 10px;
+        }
+        #chat-footer > * {
+            padding: 15px;
+            border-radius: 5px;
+            border: 1px solid #475569;
+            background: #f9fafc
+        }
+        .option:hover {
+            box-shadow: 0 0 11px #aaa;
+        }
+        #chat-input {
+            font-size: medium;
+        }
+
+        @media only screen and (max-width: 600px) {
+            body {
+                grid-template-columns: 1fr;
+                grid-template-rows: auto minmax(80px, 100%) auto;
+            }
+            body > * {
+                grid-column: 1;
+            }
+            #chat-footer {
+                padding: 0;
+                margin: 4px;
+                grid-template-columns: auto;
+            }
+        }
+        @media only screen and (min-width: 600px) {
+            body {
+                grid-template-columns: auto min(70vw, 100%) auto;
+                grid-template-rows: auto minmax(80px, 100%) auto;
+            }
+            body > * {
+                grid-column: 2;
+            }
+        }
+    </style>
 </html>

--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -32,6 +32,9 @@
                     <div class="chat-message-text">${message}</div>
                 </div>
             `;
+
+            // Scroll to bottom of input-body element
+            document.getElementById("chat-body").scrollTop = document.getElementById("chat-body").scrollHeight;
         }
 
         function chat() {

--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -1,0 +1,113 @@
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0">
+        <title>Khoj</title>
+
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 144 144%22><text y=%22.86em%22 font-size=%22144%22>🦅</text></svg>">
+        <link rel="icon" type="image/png" sizes="144x144" href="/static/assets/icons/favicon-144x144.png">
+        <link rel="manifest" href="/static/khoj.webmanifest">
+    </head>
+    <script>
+        function setTypeFieldInUrl(type) {
+            var url = new URL(window.location.href);
+            url.searchParams.set("t", type.value);
+            window.history.pushState({}, "", url.href);
+        }
+
+        function setQueryFieldInUrl(query) {
+            var url = new URL(window.location.href);
+            url.searchParams.set("q", query);
+            window.history.pushState({}, "", url.href);
+        }
+
+        function renderMessage(message, by, type_) {
+            var current_time = new Date().toLocaleTimeString();
+            document.getElementById("chat-body").innerHTML += `
+                <div class="chat-message ${type_} ${by}">
+                    <div class="chat-message-info">
+                        <div class="chat-message-name">${by}</div>
+                        <div class="chat-message-time">${current_time}</div>
+                    </div>
+                    <div class="chat-message-text">${message}</div>
+                </div>
+            `;
+        }
+
+        function chat() {
+            // Extract required fields for search from form
+            query = document.getElementById("chat-input").value.trim();
+            type_ = document.getElementById("chat-type").value;
+            console.log(`Query: ${query}, Type: ${type_}`);
+
+            // Short circuit on empty query
+            if (query.length === 0)
+                return;
+
+            // Set query field in url query param
+            setQueryFieldInUrl(query);
+
+            // Add message by user to chat body
+            renderMessage(query, "You", type_);
+            document.getElementById("chat-input").value = "";
+
+            // Generate backend API URL to execute query
+            url = type_ === "chat"
+                ? `/api/beta/chat?q=${encodeURIComponent(query)}`
+                : `/api/beta/summarize?q=${encodeURIComponent(query)}`;
+
+            // Call specified Khoj API
+            fetch(url)
+                .then(response => response.json())
+                .then(data => data.response)
+                .then(response => {
+                    // Render message by Khoj to chat body
+                    console.log(response);
+                    renderMessage(response, "Khoj", type_);
+                });
+            // document.getElementById("chat-body").innerHTML += renderMessage(response, "Khoj", type_);
+        }
+
+        function incrementalChat(event) {
+            // Send chat message on 'Enter'
+            if (event.key === 'Enter') {
+                chat();
+            }
+        }
+
+        window.onload = function () {
+            // Set welcome message on load
+            renderMessage("Hey, what's up?", "Khoj", "chat");
+
+            // Fill type field with value passed in URL query parameters, if any.
+            var type_via_url = new URLSearchParams(window.location.search).get("t");
+            if (type_via_url)
+                document.getElementById("chat-type").value = type_via_url;
+
+            // Fill query field with value passed in URL query parameters, if any.
+            var query_via_url = new URLSearchParams(window.location.search).get("q");
+            if (query_via_url) {
+                document.getElementById("chat-input").value = query_via_url;
+                chat();
+            }
+        }
+    </script>
+    <body>
+        <!-- Chat Header -->
+        <h1>Khoj</h1>
+
+        <!-- Chat Body -->
+        <div id="chat-body"></div>
+
+        <!-- Chat Footer -->
+        <div id="chat-footer">
+            <input type="text" id="chat-input" onkeyup=incrementalChat(event) autofocus="autofocus" placeholder="What is the meaning of life?">
+
+            <!--Select Chat Type from: Chat, Summarize -->
+            <select id="chat-type" onchange="setTypeFieldInUrl(this)">
+                <option value="chat">Chat</option>
+                <option value="summarize">Summarize</option>
+            </select>
+        </div>
+    </body>
+</html>

--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -10,29 +10,33 @@
     </head>
     <script>
         function setTypeFieldInUrl(type) {
-            var url = new URL(window.location.href);
+            let url = new URL(window.location.href);
             url.searchParams.set("t", type.value);
             window.history.pushState({}, "", url.href);
         }
 
         function setQueryFieldInUrl(query) {
-            var url = new URL(window.location.href);
+            let url = new URL(window.location.href);
             url.searchParams.set("q", query);
             window.history.pushState({}, "", url.href);
         }
 
-        function renderMessage(message, by, type_) {
-            var current_time = new Date().toLocaleTimeString();
+        function formatDate(date) {
+            // Format date in HH:MM, DD MMM YYYY format
+            let time_string = date.toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit', hour12: false });
+            let date_string = date.toLocaleString('en-IN', { year: 'numeric', month: 'short', day: '2-digit'}).replaceAll('-', ' ');
+            return `${time_string}, ${date_string}`;
+        }
+
+        function renderMessage(message, by, dt=null) {
+            let message_time = formatDate(dt ?? new Date());
+            let by_name =  by == "khoj" ? "🦅 Khoj" : "😲 You";
+            // Generate HTML for Chat Message and Append to Chat Body
             document.getElementById("chat-body").innerHTML += `
-                <div class="chat-message ${type_} ${by}">
-                    <div class="chat-message-info">
-                        <div class="chat-message-name">${by}</div>
-                        <div class="chat-message-time">${current_time}</div>
-                    </div>
-                    <div class="chat-message-text">${message}</div>
+                <div data-meta="${by_name} at ${message_time}" class="chat-message ${by}">
+                    <div class="chat-message-text ${by}">${message}</div>
                 </div>
             `;
-
             // Scroll to bottom of input-body element
             document.getElementById("chat-body").scrollTop = document.getElementById("chat-body").scrollHeight;
         }
@@ -51,7 +55,7 @@
             setQueryFieldInUrl(query);
 
             // Add message by user to chat body
-            renderMessage(query, "You", type_);
+            renderMessage(query, "you");
             document.getElementById("chat-input").value = "";
 
             // Generate backend API URL to execute query
@@ -66,9 +70,8 @@
                 .then(response => {
                     // Render message by Khoj to chat body
                     console.log(response);
-                    renderMessage(response, "Khoj", type_);
+                    renderMessage(response, "khoj");
                 });
-            // document.getElementById("chat-body").innerHTML += renderMessage(response, "Khoj", type_);
         }
 
         function incrementalChat(event) {
@@ -79,13 +82,13 @@
         }
 
         window.onload = function () {
-            // Set welcome message on load
-            renderMessage("Hey, what's up?", "Khoj", "chat");
-
             // Fill type field with value passed in URL query parameters, if any.
             var type_via_url = new URLSearchParams(window.location.search).get("t");
             if (type_via_url)
                 document.getElementById("chat-type").value = type_via_url;
+
+             // Set welcome message on load
+            renderMessage("Hey, what's up?", "khoj");
 
             // Fill query field with value passed in URL query parameters, if any.
             var query_via_url = new URLSearchParams(window.location.search).get("q");
@@ -145,6 +148,61 @@
             margin: 0px;
             line-height: 20px;
             overflow-y: scroll;
+        }
+        .chat-message::after {
+            content: attr(data-meta);
+            display: block;
+            font-size: x-small;
+            color: #475569;
+            margin: -12px 7px 0 -5px;
+        }
+        .chat-message.khoj {
+            margin-left: auto;
+            text-align: left;
+        }
+        .chat-message.you {
+            margin-right: auto;
+            text-align: right;
+        }
+        .chat-message-text {
+            margin: 10px;
+            border-radius: 10px;
+            padding: 10px;
+            position: relative;
+            display: inline-block;
+            max-width: 80%;
+            text-align: left;
+        }
+        .chat-message-text.khoj {
+            color: #f8fafc;
+            background: #017eff;
+            margin-left: auto;
+        }
+        .chat-message-text.khoj:after {
+            content: '';
+            position: absolute;
+            bottom: -2px;
+            left: -7px;
+            border: 10px solid transparent;
+            border-top-color: #017eff;
+            border-bottom: 0;
+            transform: rotate(-60deg);
+        }
+        .chat-message-text.you {
+            color: #f8fafc;
+            background: #475569;
+            margin-right: auto;
+        }
+        .chat-message-text.you:after {
+            content: '';
+            position: absolute;
+            top: 91%;
+            right: -2px;
+            border: 10px solid transparent;
+            border-left-color: #475569;
+            border-right: 0;
+            margin-top: -10px;
+            transform: rotate(-60deg)
         }
 
         #chat-footer {

--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -87,6 +87,16 @@
             if (type_via_url)
                 document.getElementById("chat-type").value = type_via_url;
 
+            fetch('/api/beta/chat')
+                .then(response => response.json())
+                .then(data => data.response)
+                .then(chat_logs => {
+                    // Render conversation history, if any
+                    chat_logs.forEach(chat_log => {
+                        renderMessage(chat_log.message, chat_log.by, new Date(chat_log.created));
+                    });
+                });
+
              // Set welcome message on load
             renderMessage("Hey, what's up?", "khoj");
 

--- a/src/interface/web/chat.html
+++ b/src/interface/web/chat.html
@@ -148,8 +148,9 @@
             font-size: medium;
             margin: 0px;
             line-height: 20px;
-            overflow-y: scroll;
+            overflow-y: scroll; /* Make chat body scroll to see history */
         }
+        /* add chat metatdata to bottom of bubble */
         .chat-message::after {
             content: attr(data-meta);
             display: block;
@@ -157,14 +158,17 @@
             color: #475569;
             margin: -12px 7px 0 -5px;
         }
+        /* move message by khoj to left */
         .chat-message.khoj {
             margin-left: auto;
             text-align: left;
         }
+        /* move message by you to right */
         .chat-message.you {
             margin-right: auto;
             text-align: right;
         }
+        /* basic style chat message text */
         .chat-message-text {
             margin: 10px;
             border-radius: 10px;
@@ -174,11 +178,13 @@
             max-width: 80%;
             text-align: left;
         }
+        /* color chat bubble by khoj blue */
         .chat-message-text.khoj {
             color: #f8fafc;
             background: #017eff;
             margin-left: auto;
         }
+        /* add left protrusion to khoj chat bubble */
         .chat-message-text.khoj:after {
             content: '';
             position: absolute;
@@ -189,11 +195,13 @@
             border-bottom: 0;
             transform: rotate(-60deg);
         }
+        /* color chat bubble by you dark grey */
         .chat-message-text.you {
             color: #f8fafc;
             background: #475569;
             margin-right: auto;
         }
+        /* add right protrusion to you chat bubble */
         .chat-message-text.you:after {
             content: '';
             position: absolute;

--- a/src/processor/conversation/gpt.py
+++ b/src/processor/conversation/gpt.py
@@ -210,19 +210,30 @@ def message_to_prompt(user_message, conversation_history="", gpt_message=None, s
     return f"{conversation_history}{restart_sequence} {user_message}{start_sequence}{gpt_message}"
 
 
-def message_to_log(user_message, user_message_metadata, gpt_message, conversation_log=[]):
+def message_to_log(user_message, gpt_message, user_message_metadata={}, conversation_log=[]):
     """Create json logs from messages, metadata for conversation log"""
+    default_user_message_metadata = {
+        "intent": {
+            "type": "remember",
+            "memory-type": "notes",
+            "query": user_message
+        },
+        "trigger-emotion": "calm"
+    }
+    current_dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
     # Create json log from Human's message
-    human_log = user_message_metadata
+    human_log = user_message_metadata or default_user_message_metadata
     human_log["message"] = user_message
-    human_log["by"] = "Human"
-    human_log["created"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    human_log["by"] = "you"
+    human_log["created"] = current_dt
 
     # Create json log from GPT's response
-    ai_log = {"message": gpt_message, "by": "AI", "created": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+    khoj_log = {"message": gpt_message, "by": "khoj", "created": current_dt}
 
-    conversation_log.extend([human_log, ai_log])
+    conversation_log.extend([human_log, khoj_log])
     return conversation_log
+
 
 def extract_summaries(metadata):
     """Extract summaries from metadata"""

--- a/src/processor/conversation/gpt.py
+++ b/src/processor/conversation/gpt.py
@@ -31,7 +31,7 @@ Summarize the below notes about {user_query}:
 
 {text}
 
-Summarize the notes in second person perspective and use past tense:'''
+Summarize the notes in second person perspective:'''
 
     # Get Response from GPT
     response = openai.Completion.create(

--- a/src/routers/api_beta.py
+++ b/src/routers/api_beta.py
@@ -100,7 +100,7 @@ def chat(q: Optional[str]=None):
 
     # Update Conversation History
     state.processor_config.conversation.chat_session = message_to_prompt(q, chat_session, gpt_message=gpt_response)
-    state.processor_config.conversation.meta_log['chat'] = message_to_log(q, metadata, gpt_response, meta_log.get('chat', []))
+    state.processor_config.conversation.meta_log['chat'] = message_to_log(q, gpt_response, metadata, meta_log.get('chat', []))
 
     return {'status': status, 'response': gpt_response}
 

--- a/src/routers/api_beta.py
+++ b/src/routers/api_beta.py
@@ -47,6 +47,10 @@ def summarize_beta(q: str):
     model = state.processor_config.conversation.model
     api_key = state.processor_config.conversation.openai_api_key
 
+    # Load Conversation History
+    chat_session = state.processor_config.conversation.chat_session
+    meta_log = state.processor_config.conversation.meta_log
+
     # Converse with OpenAI GPT
     result_list = search(q, n=1, t=SearchType.Org, r=True)
     collated_result = "\n".join([item.entry for item in result_list])
@@ -57,6 +61,10 @@ def summarize_beta(q: str):
     except Exception as e:
         gpt_response = str(e)
         status = 'error'
+
+    # Update Conversation History
+    state.processor_config.conversation.chat_session = message_to_prompt(q, chat_session, gpt_message=gpt_response)
+    state.processor_config.conversation.meta_log['chat'] = message_to_log(q, gpt_response, conversation_log=meta_log.get('chat', []))
 
     return {'status': status, 'response': gpt_response}
 

--- a/src/routers/api_beta.py
+++ b/src/routers/api_beta.py
@@ -62,7 +62,7 @@ def summarize_beta(q: str):
 
 
 @api_beta.get('/chat')
-def chat(q: str):
+def chat(q: Optional[str]=None):
     # Initialize Variables
     model = state.processor_config.conversation.model
     api_key = state.processor_config.conversation.openai_api_key
@@ -70,6 +70,10 @@ def chat(q: str):
     # Load Conversation History
     chat_session = state.processor_config.conversation.chat_session
     meta_log = state.processor_config.conversation.meta_log
+
+    # If user query is empty, return chat history
+    if not q:
+        return {'status': 'ok', 'response': meta_log["chat"]}
 
     # Converse with OpenAI GPT
     metadata = understand(q, model=model, api_key=api_key, verbose=state.verbose)

--- a/src/routers/web_client.py
+++ b/src/routers/web_client.py
@@ -21,3 +21,7 @@ def index():
 @web_client.get('/config', response_class=HTMLResponse)
 def config_page(request: Request):
     return templates.TemplateResponse("config.html", context={'request': request})
+
+@web_client.get("/chat", response_class=FileResponse)
+def chat_page():
+    return FileResponse(constants.web_directory / "chat.html")


### PR DESCRIPTION
### Overview
- Provide a chat interface to engage with and inquire your notes
- Simplify interacting with the beta `chat` and `summarize` APIs

### Use
- Open `<khoj-url>/chat`, by default at http://localhost:8000/chat?type=summarize
- Type your queries, see summarized response by Khoj from your notes

**Note**:
 - **You will need to add an API key from OpenAI to your khoj.yml**
 - **Your query and top note from search result will be sent to OpenAI for processing**

## Details
- 177756b Show chat history on loading chat page on web interface
- d8ee0f0 Save chat history to disk for persistence, seeing chat logs
- 5294693 Style chat messages as speech bubbles
- d170747 Add khoj web interface and chat styling to new chat page on khoj web
- de6c146 Implement functional, unstyled chat page for khoj web interface

## Demo
<img width="203" alt="khoj_chat_web_interface" src="https://user-images.githubusercontent.com/6413477/212445631-4f600ae4-b8f1-4a80-8248-6f9f99e3154e.png">
