### PR TITLE
Search for Similar Notes from Obsidian Plugin

### DIFF
--- a/src/interface/obsidian/src/main.ts
+++ b/src/interface/obsidian/src/main.ts
@@ -21,6 +21,17 @@ export default class Khoj extends Plugin {
             }
         });
 
+        // Add a similar notes command
+        this.addCommand({
+            id: 'similar',
+            name: 'Find Similar Notes',
+            checkCallback: (checking) => {
+                if (!checking && this.settings.connectedToBackend)
+                    new KhojModal(this.app, this.settings, true).open();
+                return this.settings.connectedToBackend;
+            }
+        });
+
         // Create an icon in the left ribbon.
         this.addRibbonIcon('search', 'Khoj', (_: MouseEvent) => {
             // Called when the user clicks the icon.

--- a/src/interface/obsidian/src/main.ts
+++ b/src/interface/obsidian/src/main.ts
@@ -10,7 +10,7 @@ export default class Khoj extends Plugin {
     async onload() {
         await this.loadSettings();
 
-        // Add a search command. It can be triggered from anywhere
+        // Add search command. It can be triggered from anywhere
         this.addCommand({
             id: 'search',
             name: 'Search',
@@ -21,11 +21,11 @@ export default class Khoj extends Plugin {
             }
         });
 
-        // Add a similar notes command
+        // Add similar notes command. It can only be triggered from the editor
         this.addCommand({
             id: 'similar',
             name: 'Find Similar Notes',
-            checkCallback: (checking) => {
+            editorCheckCallback: (checking) => {
                 if (!checking && this.settings.connectedToBackend)
                     new KhojModal(this.app, this.settings, true).open();
                 return this.settings.connectedToBackend;
@@ -36,8 +36,8 @@ export default class Khoj extends Plugin {
         this.addRibbonIcon('search', 'Khoj', (_: MouseEvent) => {
             // Called when the user clicks the icon.
             this.settings.connectedToBackend
-            ? new KhojModal(this.app, this.settings).open()
-            : new Notice(`❗️Ensure Khoj backend is running and Khoj URL is pointing to it in the plugin settings`);
+                ? new KhojModal(this.app, this.settings).open()
+                : new Notice(`❗️Ensure Khoj backend is running and Khoj URL is pointing to it in the plugin settings`);
         });
 
         // Add a settings tab so the user can configure khoj

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -51,7 +51,8 @@ export class KhojModal extends SuggestModal<SearchResult> {
 
     async getSuggestions(query: string): Promise<SearchResult[]> {
         // Query Khoj backend for search results
-        let searchUrl = `${this.setting.khojUrl}/api/search?q=${query}&n=${this.setting.resultsCount}&r=${this.rerank}&t=markdown`
+        let encodedQuery = encodeURIComponent(query);
+        let searchUrl = `${this.setting.khojUrl}/api/search?q=${encodedQuery}&n=${this.setting.resultsCount}&r=${this.rerank}&t=markdown`
         let results = await request(searchUrl)
             .then(response => JSON.parse(response))
             .then(data => data

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -54,15 +54,8 @@ export class KhojModal extends SuggestModal<SearchResult> {
         let searchUrl = `${this.setting.khojUrl}/api/search?q=${query}&n=${this.setting.resultsCount}&r=${this.rerank}&t=markdown`
         let results = await request(searchUrl)
             .then(response => JSON.parse(response))
-            .then(data => {
-                return data.map((result: any) => {
-                    let processedResult: SearchResult = {
-                        entry: result.entry,
-                        file: result.additional.file
-                    };
-                    return processedResult;
-                })
-            });
+            .then(data => data
+                .map((result: any) => { return { entry: result.entry, file: result.additional.file } as SearchResult; }));
 
         return results;
     }

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -9,10 +9,15 @@ export interface SearchResult {
 export class KhojModal extends SuggestModal<SearchResult> {
     setting: KhojSetting;
     rerank: boolean = false;
+    find_similar_notes: boolean;
 
-    constructor(app: App, setting: KhojSetting) {
+    constructor(app: App, setting: KhojSetting, find_similar_notes: boolean = false) {
         super(app);
         this.setting = setting;
+        this.find_similar_notes = find_similar_notes;
+
+        // Hide input element in Similar Notes mode
+        this.inputEl.hidden = this.find_similar_notes;
 
         // Register Modal Keybindings to Rerank Results
         this.scope.register(['Mod'], 'Enter', async () => {
@@ -49,6 +54,25 @@ export class KhojModal extends SuggestModal<SearchResult> {
         this.setPlaceholder('Search with Khoj 🦅...');
     }
 
+    async onOpen() {
+        if (this.find_similar_notes) {
+            // If markdown file is currently active
+            let file = this.app.workspace.getActiveFile();
+            if (file && file.extension === 'md') {
+                // Enable rerank of search results
+                this.rerank = true
+                // Set contents of active markdown file to input element
+                this.inputEl.value = await this.app.vault.read(file);
+                // Trigger search to get and render similar notes from khoj backend
+                this.inputEl.dispatchEvent(new Event('input'));
+                this.rerank = false
+            }
+            else {
+                this.resultContainerEl.setText('Cannot find similar notes for non-markdown files');
+            }
+        }
+    }
+
     async getSuggestions(query: string): Promise<SearchResult[]> {
         // Query Khoj backend for search results
         let encodedQuery = encodeURIComponent(query);
@@ -56,6 +80,7 @@ export class KhojModal extends SuggestModal<SearchResult> {
         let results = await request(searchUrl)
             .then(response => JSON.parse(response))
             .then(data => data
+                .filter((result: any) => !this.find_similar_notes || !result.additional.file.endsWith(this.app.workspace.getActiveFile()?.path))
                 .map((result: any) => { return { entry: result.entry, file: result.additional.file } as SearchResult; }));
 
         return results;


### PR DESCRIPTION
Allow users to search for notes similar to the current one they are viewing

## Main Changes
- 39a18e2 Extend search modal to search for similar notes
  - Hide input field on init, Trigger search on opening modal when in similar notes mode
  - Set input to current markdown file and get similar notes to it
  - Enable rerank when searching for similar notes
  - Filter out current note from similar note search results
- 0bed410 Limit Find Similar Note command to be triggered from Editor