### PR TITLE
Find Similar Notes, Transactions, Images from Khoj in Emacs

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -50,7 +50,7 @@
 (require 'json)
 (require 'transient)
 
-
+
 ;; -------------------------
 ;; Khoj Static Configuration
 ;; -------------------------
@@ -84,7 +84,7 @@
                  (const "image")
                  (const "music")))
 
-
+
 ;; --------------------------
 ;; Khoj Dynamic Configuration
 ;; --------------------------
@@ -160,7 +160,7 @@ Use `which-key` if available, else display simple message in echo area"
                                 nil t t))
     (message "%s" (khoj--keybindings-info-message))))
 
-
+
 ;; -----------------------------------------------
 ;; Extract and Render Entries of each Content Type
 ;; -----------------------------------------------
@@ -247,7 +247,7 @@ Use `which-key` if available, else display simple message in echo area"
      ((and (member 'markdown enabled-content-types) (or (equal file-extension "markdown") (equal file-extension "md"))) "markdown")
      (t khoj-default-content-type))))
 
-
+
 ;; --------------
 ;; Query Khoj API
 ;; --------------
@@ -304,7 +304,7 @@ Render results in BUFFER-NAME."
             (t (fundamental-mode))))
     (read-only-mode t)))
 
-
+
 ;; ------------------
 ;; Incremental Search
 ;; ------------------
@@ -379,6 +379,7 @@ Render results in BUFFER-NAME."
       (read-string khoj--query-prompt))))
 
 
+
 ;; ---------
 ;; Khoj Menu
 ;; ---------
@@ -424,7 +425,7 @@ Render results in BUFFER-NAME."
     ("u" "Update" khoj--update-command)
     ("q" "Quit" transient-quit-one)]])
 
-
+
 ;; ----------
 ;; Entrypoint
 ;; ----------

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -275,9 +275,8 @@ Use `which-key` if available, else display simple message in echo area"
         (encoded-query (url-hexify-string query)))
     (format "%s/api/search?q=%s&t=%s&r=%s&n=%s" khoj-server-url encoded-query content-type rerank khoj-results-count)))
 
-(defun khoj--query-api-and-render-results (query content-type query-url buffer-name)
-  "Query Khoj API using QUERY, CONTENT-TYPE, QUERY-URL.
-Render results in BUFFER-NAME."
+(defun khoj--query-api-and-render-results (query-url content-type query buffer-name)
+  "Query Khoj QUERY-URL. Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
   ;; get json response from api
   (with-current-buffer buffer-name
     (let ((inhibit-read-only t)
@@ -335,9 +334,9 @@ Render results in BUFFER-NAME."
           (setq khoj--rerank t)
           (message "Khoj: Rerank Results"))
         (khoj--query-api-and-render-results
-         query
-         khoj--content-type
          query-url
+         khoj--content-type
+         query
          khoj-buffer-name))))))
 
 (defun khoj--delete-open-network-connections-to-server ()
@@ -438,9 +437,9 @@ Render results in BUFFER-NAME."
          (buffer-name (get-buffer-create khoj--buffer-name)))
     (progn
       (khoj--query-api-and-render-results
-       query-title
-       content-type
        query-url
+       content-type
+       query-title
        buffer-name)
       (switch-to-buffer buffer-name)
       (goto-char (point-min)))))


### PR DESCRIPTION
### Overview
Find items of specified type similar to current text item at point

### Capabilities
- Support querying with text surrounding point in any text buffer
- Find similar items of specified content type indexed on Khoj

### Details
- Query using text in current section if in a `outline-mode` buffer (i.e markdown heading, org-mode entry text)
- Query using text in current paragraph if in non `outline-mode` buffer
- Search for items of `content-type` set in khoj transient menu
- Update last used khoj content-type and results from the
  *find-similar* and *update* functions for later reuse

### Related
- Recently added [Find Similar Notes in Khoj Obsidian](https://github.com/debanjum/khoj/pull/122) as well