### PR TITLE
Restyled Obsidian Search Results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ main.js
 
 # obsidian
 data.json
+
+# symlink to configuratio file
+.khoj

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -1,4 +1,4 @@
-import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform, TFile } from 'obsidian';
+import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform} from 'obsidian';
 import { KhojSetting } from 'src/settings';
 
 export interface SearchResult {

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -105,7 +105,7 @@ export class KhojModal extends SuggestModal<SearchResult> {
             path = result.file.split('/').slice(0, -1).join('/');
             basename = result.file.split('/').slice(-1)[0];
         }
-
+        basename = basename.replace('.md', '');
         let entry_lines_split = result.entry.split('\n')
         // remove frontmatter if present
         if (entry_lines_split[0] == '# ---'){

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -1,4 +1,4 @@
-import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform } from 'obsidian';
+import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform, TFile } from 'obsidian';
 import { KhojSetting } from 'src/settings';
 
 export interface SearchResult {
@@ -93,6 +93,18 @@ export class KhojModal extends SuggestModal<SearchResult> {
         // Max Size (words or number of lines)
         let lines_to_render = 5;
         let words_to_render = 30;
+        var path = "";
+        var basename = "";
+
+        // set path and basename of file depending on OS
+        if (result.file.indexOf('\\') > -1) {
+            path = result.file.split('\\').slice(0, -1).join('\\');
+            basename = result.file.split('\\').slice(-1)[0];
+        }
+        if (result.file.indexOf('/') > -1) {
+            path = result.file.split('/').slice(0, -1).join('/');
+            basename = result.file.split('/').slice(-1)[0];
+        }
 
         let entry_lines_split = result.entry.split('\n')
         // remove frontmatter if present
@@ -109,12 +121,10 @@ export class KhojModal extends SuggestModal<SearchResult> {
         let entry_lines = entry_lines_split.slice(0, lines_to_render).join('\n');
         let entry_words_split = entry_lines.split(' ');
         let entry_snipped_indicator = entry_words_split.length > words_to_render ? ' **...**' : '';
-        let entry_words = entry_words_split.slice(0, words_to_render).join(' ');
-        let result_file = "";
-        result_file = result.file.split('/').pop();
-        el.createEl("div",{ cls: 'khoj-result-file' }).setText(result_file);
+        let entry_words = entry_words_split.slice(0, words_to_render).join(' ').trim();
+        el.createEl("div",{ cls: 'khoj-result-file' }).setText(basename);
         var result_div = el.createEl("div", { cls: 'khoj-result-entry' })
-        MarkdownRenderer.renderMarkdown(entry_words + entry_snipped_indicator, result_div, null, null);
+        MarkdownRenderer.renderMarkdown(entry_words + entry_snipped_indicator, result_div, path, null);
     }
 
     async onChooseSuggestion(result: SearchResult, _: MouseEvent | KeyboardEvent) {

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -1,4 +1,4 @@
-import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform, TFile } from 'obsidian';
+import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform } from 'obsidian';
 import { KhojSetting } from 'src/settings';
 
 export interface SearchResult {

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -91,7 +91,7 @@ export class KhojModal extends SuggestModal<SearchResult> {
 
     async renderSuggestion(result: SearchResult, el: HTMLElement) {
         // Max Size (words or number of lines)
-        let lines_to_render = 5;
+        let lines_to_render = 8;
         let words_to_render = 30;
         var path = "";
         var basename = "";
@@ -118,6 +118,7 @@ export class KhojModal extends SuggestModal<SearchResult> {
                 }
             }
         }
+        entry_lines_split = entry_lines_split.join('\n').trim().split('\n');
         let entry_lines = entry_lines_split.slice(0, lines_to_render).join('\n');
         let entry_words_split = entry_lines.split(' ');
         let entry_snipped_indicator = entry_words_split.length > words_to_render ? ' **...**' : '';

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -1,4 +1,4 @@
-import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform } from 'obsidian';
+import { App, SuggestModal, request, MarkdownRenderer, Instruction, Platform, TFile } from 'obsidian';
 import { KhojSetting } from 'src/settings';
 
 export interface SearchResult {
@@ -95,7 +95,6 @@ export class KhojModal extends SuggestModal<SearchResult> {
         let words_to_render = 30;
 
         let entry_lines_split = result.entry.split('\n')
-        // console.log(result.entry)
         // remove frontmatter if present
         if (entry_lines_split[0] == '# ---'){
             //loop through lines until we find the end of the frontmatter
@@ -108,14 +107,14 @@ export class KhojModal extends SuggestModal<SearchResult> {
             }
         }
         let entry_lines = entry_lines_split.slice(0, lines_to_render).join('\n');
-        let entry_words = entry_lines.split(' ');
-        let entry_snipped_indicator = entry_words.length > words_to_render ? ' **...**' : '';
-        let snipped_entry = entry_words.slice(0, words_to_render).join(' ');
-        el.createEl("div",{ cls: 'khoj-result-file' }).setText(result.file);
-        var result_div = el.createEl("div", { cls: 'khoj-result-entry' }) //.setText(snipped_entry + entry_snipped_indicator);
-        
-        // el.createDiv({ cls: 'khoj-result-entry' }).setText(snipped_entry + entry_snipped_indicator);
-        MarkdownRenderer.renderMarkdown(snipped_entry + entry_snipped_indicator, result_div, null, null);
+        let entry_words_split = entry_lines.split(' ');
+        let entry_snipped_indicator = entry_words_split.length > words_to_render ? ' **...**' : '';
+        let entry_words = entry_words_split.slice(0, words_to_render).join(' ');
+        let result_file = "";
+        result_file = result.file.split('/').pop();
+        el.createEl("div",{ cls: 'khoj-result-file' }).setText(result_file);
+        var result_div = el.createEl("div", { cls: 'khoj-result-entry' })
+        MarkdownRenderer.renderMarkdown(entry_words + entry_snipped_indicator, result_div, null, null);
     }
 
     async onChooseSuggestion(result: SearchResult, _: MouseEvent | KeyboardEvent) {

--- a/src/interface/obsidian/src/modal.ts
+++ b/src/interface/obsidian/src/modal.ts
@@ -90,11 +90,32 @@ export class KhojModal extends SuggestModal<SearchResult> {
     }
 
     async renderSuggestion(result: SearchResult, el: HTMLElement) {
+        // Max Size (words or number of lines)
+        let lines_to_render = 5;
         let words_to_render = 30;
-        let entry_words = result.entry.split(' ')
+
+        let entry_lines_split = result.entry.split('\n')
+        // console.log(result.entry)
+        // remove frontmatter if present
+        if (entry_lines_split[0] == '# ---'){
+            //loop through lines until we find the end of the frontmatter
+            for (let i = 1; i < entry_lines_split.length; i++){
+                if (entry_lines_split[i] == '---'){
+                    //remove the frontmatter
+                    entry_lines_split = entry_lines_split.slice(i+1);
+                    break;
+                }
+            }
+        }
+        let entry_lines = entry_lines_split.slice(0, lines_to_render).join('\n');
+        let entry_words = entry_lines.split(' ');
         let entry_snipped_indicator = entry_words.length > words_to_render ? ' **...**' : '';
         let snipped_entry = entry_words.slice(0, words_to_render).join(' ');
-        MarkdownRenderer.renderMarkdown(snipped_entry + entry_snipped_indicator, el, null, null);
+        el.createEl("div",{ cls: 'khoj-result-file' }).setText(result.file);
+        var result_div = el.createEl("div", { cls: 'khoj-result-entry' }) //.setText(snipped_entry + entry_snipped_indicator);
+        
+        // el.createDiv({ cls: 'khoj-result-entry' }).setText(snipped_entry + entry_snipped_indicator);
+        MarkdownRenderer.renderMarkdown(snipped_entry + entry_snipped_indicator, result_div, null, null);
     }
 
     async onChooseSuggestion(result: SearchResult, _: MouseEvent | KeyboardEvent) {

--- a/src/interface/obsidian/styles.css
+++ b/src/interface/obsidian/styles.css
@@ -6,3 +6,24 @@ available in the app when your plugin is enabled.
 If your plugin does not need CSS, delete this file.
 
 */
+.khoj-result-file {
+    font-weight: 600;
+  }
+  
+  .khoj-result-entry {
+    color: var(--text-muted);
+    margin-left: 2em;
+    padding-left: 0.5em;
+    line-height: normal;
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+    border-left-style: solid;
+    border-left-color: var(--color-accent-2);
+    white-space: normal;
+  }
+
+  .khoj-result-entry > * {
+    /* margin-top: 0;
+    margin-bottom: 0; */
+    font-size: medium;
+  }

--- a/src/interface/obsidian/styles.css
+++ b/src/interface/obsidian/styles.css
@@ -23,7 +23,5 @@ If your plugin does not need CSS, delete this file.
   }
 
   .khoj-result-entry > * {
-    /* margin-top: 0;
-    margin-bottom: 0; */
     font-size: medium;
   }

--- a/src/interface/obsidian/styles.css
+++ b/src/interface/obsidian/styles.css
@@ -25,3 +25,12 @@ If your plugin does not need CSS, delete this file.
   .khoj-result-entry > * {
     font-size: medium;
   }
+
+  .khoj-result-entry > p {
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+  }
+
+  .khoj-result-entry .internal-embed:not(.image-embed) {
+    display: inline-block;
+  }

--- a/src/interface/obsidian/styles.css
+++ b/src/interface/obsidian/styles.css
@@ -31,6 +31,6 @@ If your plugin does not need CSS, delete this file.
     margin-bottom: 0.2em;
   }
 
-  .khoj-result-entry .internal-embed:not(.image-embed) {
-    display: inline-block;
+  .khoj-result-entry p br {
+    display: none;
   }


### PR DESCRIPTION
Thought search results were a bit hard to interpret, so I restyled them a bit. Sorry, I'm not a developer so apologizes in advance if there's etiquette around contributions I'm missing.

Here's what the search results look like:

<img width="1260" alt="image" src="https://user-images.githubusercontent.com/9954186/216818786-794483b7-96ca-4514-acb8-8267c69ad12d.png">

It should maintain reasonable contrast with most themes as the CSS uses theme variables rather than hard coded colors. 

Should work with Mac, Windows and Linux, though I've only tested it on Mac. The interoperability challenge comes from the fact that the API returns a path as a string, which presumably would have different slashes on OSX, Linux compared to windows?

Also addresses this issue: #134 

Cheers,