### PR TITLE
Fix obsidian plugins doc link

### DIFF
--- a/src/interface/obsidian/README.md
+++ b/src/interface/obsidian/README.md
@@ -55,7 +55,7 @@ pip install khoj-assistant && khoj --no-gui
   1. Open [Khoj](https://obsidian.md/plugins?id=khoj) from the *Community plugins* tab in Obsidian settings panel
   2. Click *Install*, then *Enable* on the Khoj plugin page in Obsidian
 
-See [official docs](https://help.obsidian.md/Advanced+topics/Community+plugins#Discover+and+install+community+plugins) for details
+See [official Obsidian plugin docs](https://help.obsidian.md/Extending+Obsidian/Community+plugins) for details
 
 ## Use
 ### Search


### PR DESCRIPTION
Also make it more obvious where the link is going, initially I thought the link was to another official khoj documentation site.