### PR TITLE
Enable Creating Content Plugins

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -244,6 +244,18 @@ Use `which-key` if available, else display simple message in echo area"
       ;; remove trailing (, ) or SPC from extracted entries string
       (replace-regexp-in-string "[\(\) ]$" ""))))
 
+(defun khoj--extract-entries (json-response query)
+  "Convert JSON-RESPONSE, QUERY from API to text entries."
+  (thread-last json-response
+               ;; extract and render entries from API response
+               (mapcar (lambda (args) (format "%s\n\n" (cdr (assoc 'entry args)))))
+               ;; Set query as heading in rendered results buffer
+               (format "# Query: %s\n\n%s\n" query)
+               ;; remove leading (, ) or SPC from extracted entries string
+               (replace-regexp-in-string "^[\(\) ]" "")
+               ;; remove trailing (, ) or SPC from extracted entries string
+               (replace-regexp-in-string "[\(\) ]$" "")))
+
 (defun khoj--buffer-name-to-content-type (buffer-name)
   "Infer content type based on BUFFER-NAME."
   (let ((enabled-content-types (khoj--get-enabled-content-types))
@@ -296,7 +308,7 @@ Use `which-key` if available, else display simple message in echo area"
              ((equal content-type "markdown") (khoj--extract-entries-as-markdown json-response query))
              ((equal content-type "ledger") (khoj--extract-entries-as-ledger json-response query))
              ((equal content-type "image") (khoj--extract-entries-as-images json-response query))
-             (t (format "%s" json-response))))
+             (t (khoj--extract-entries json-response query))))
       (cond ((equal content-type "org") (progn (org-mode)
                                                (visual-line-mode)))
             ((equal content-type "markdown") (progn (markdown-mode)

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -262,19 +262,15 @@ Use `which-key` if available, else display simple message in echo area"
 
 (defun khoj--get-enabled-content-types ()
   "Get content types enabled for search from API."
-  (let ((config-url (format "%s/api/config/data" khoj-server-url))
+  (let ((config-url (format "%s/api/config/types" khoj-server-url))
         (url-request-method "GET"))
     (with-temp-buffer
       (erase-buffer)
       (url-insert-file-contents config-url)
-      (let* ((json-response (json-parse-buffer :object-type 'alist))
-            (content-type (cdr (assoc 'content-type json-response))))
-        ;; return content-type items with configuration
-        (mapcar
-         #'car
-         (cl-remove-if-not
-          (lambda (a) (not (eq (cdr a) :null)))
-          content-type))))))
+      (thread-last
+        (json-parse-buffer :object-type 'alist)
+        (mapcar 'downcase)
+        (mapcar 'intern)))))
 
 (defun khoj--construct-api-query (query content-type &optional rerank)
   "Construct API Query from QUERY, CONTENT-TYPE and (optional) RERANK params."

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -281,7 +281,6 @@ Use `which-key` if available, else display simple message in echo area"
       (url-insert-file-contents config-url)
       (thread-last
         (json-parse-buffer :object-type 'alist)
-        (mapcar 'downcase)
         (mapcar 'intern)))))
 
 (defun khoj--construct-api-query (query content-type &optional rerank)

--- a/src/khoj/configure.py
+++ b/src/khoj/configure.py
@@ -2,6 +2,7 @@
 import sys
 import logging
 import json
+from enum import Enum
 
 # External Packages
 import schedule
@@ -14,7 +15,7 @@ from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
 from khoj.search_type import image_search, text_search
 from khoj.utils.config import SearchType, SearchModels, ProcessorConfigModel, ConversationProcessorConfigModel
 from khoj.utils import state
-from khoj.utils.helpers import LRU, resolve_absolute_path
+from khoj.utils.helpers import LRU, resolve_absolute_path, merge_dicts
 from khoj.utils.rawconfig import FullConfig, ProcessorConfig
 from khoj.search_filter.date_filter import DateFilter
 from khoj.search_filter.word_filter import WordFilter
@@ -40,8 +41,9 @@ def configure_server(args, required=False):
     # Initialize Processor from Config
     state.processor_config = configure_processor(args.config.processor)
 
-    # Initialize the search model from Config
+    # Initialize the search type and model from Config
     state.search_index_lock.acquire()
+    state.SearchType = configure_search_types(state.config)
     state.model = configure_search(state.model, state.config, args.regenerate)
     state.search_index_lock.release()
 
@@ -54,9 +56,19 @@ def update_search_index():
     logger.info("Search Index updated via Scheduler")
 
 
-def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, t: SearchType = None):
+def configure_search_types(config: FullConfig):
+    # Extract core search types
+    core_search_types = {e.name: e.value for e in SearchType}
+    # Extract configured plugin search types
+    plugin_search_types = {plugin_type: plugin_type for plugin_type in config.content_type.plugins.keys()}
+
+    # Dynamically generate search type enum by merging core search types with configured plugin search types
+    return Enum("SearchType", merge_dicts(core_search_types, plugin_search_types))
+
+
+def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, t: state.SearchType = None):
     # Initialize Org Notes Search
-    if (t == SearchType.Org or t == None) and config.content_type.org:
+    if (t == state.SearchType.Org or t == None) and config.content_type.org:
         # Extract Entries, Generate Notes Embeddings
         model.orgmode_search = text_search.setup(
             OrgToJsonl,
@@ -67,7 +79,7 @@ def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, 
         )
 
     # Initialize Org Music Search
-    if (t == SearchType.Music or t == None) and config.content_type.music:
+    if (t == state.SearchType.Music or t == None) and config.content_type.music:
         # Extract Entries, Generate Music Embeddings
         model.music_search = text_search.setup(
             OrgToJsonl,
@@ -78,7 +90,7 @@ def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, 
         )
 
     # Initialize Markdown Search
-    if (t == SearchType.Markdown or t == None) and config.content_type.markdown:
+    if (t == state.SearchType.Markdown or t == None) and config.content_type.markdown:
         # Extract Entries, Generate Markdown Embeddings
         model.markdown_search = text_search.setup(
             MarkdownToJsonl,
@@ -89,7 +101,7 @@ def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, 
         )
 
     # Initialize Ledger Search
-    if (t == SearchType.Ledger or t == None) and config.content_type.ledger:
+    if (t == state.SearchType.Ledger or t == None) and config.content_type.ledger:
         # Extract Entries, Generate Ledger Embeddings
         model.ledger_search = text_search.setup(
             BeancountToJsonl,
@@ -100,7 +112,7 @@ def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, 
         )
 
     # Initialize Image Search
-    if (t == SearchType.Image or t == None) and config.content_type.image:
+    if (t == state.SearchType.Image or t == None) and config.content_type.image:
         # Extract Entries, Generate Image Embeddings
         model.image_search = image_search.setup(
             config.content_type.image, search_config=config.search_type.image, regenerate=regenerate

--- a/src/khoj/configure.py
+++ b/src/khoj/configure.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 # External Packages
 import schedule
+from fastapi.staticfiles import StaticFiles
 
 # Internal Packages
 from khoj.processor.ledger.beancount_to_jsonl import BeancountToJsonl
@@ -13,8 +14,8 @@ from khoj.processor.jsonl.jsonl_to_jsonl import JsonlToJsonl
 from khoj.processor.markdown.markdown_to_jsonl import MarkdownToJsonl
 from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
 from khoj.search_type import image_search, text_search
+from khoj.utils import constants, state
 from khoj.utils.config import SearchType, SearchModels, ProcessorConfigModel, ConversationProcessorConfigModel
-from khoj.utils import state
 from khoj.utils.helpers import LRU, resolve_absolute_path, merge_dicts
 from khoj.utils.rawconfig import FullConfig, ProcessorConfig
 from khoj.search_filter.date_filter import DateFilter
@@ -46,6 +47,18 @@ def configure_server(args, required=False):
     state.SearchType = configure_search_types(state.config)
     state.model = configure_search(state.model, state.config, args.regenerate)
     state.search_index_lock.release()
+
+
+def configure_routes(app):
+    # Import APIs here to setup search types before while configuring server
+    from khoj.routers.api import api
+    from khoj.routers.api_beta import api_beta
+    from khoj.routers.web_client import web_client
+
+    app.mount("/static", StaticFiles(directory=constants.web_directory), name="static")
+    app.include_router(api, prefix="/api")
+    app.include_router(api_beta, prefix="/api/beta")
+    app.include_router(web_client)
 
 
 @schedule.repeat(schedule.every(1).hour)

--- a/src/khoj/configure.py
+++ b/src/khoj/configure.py
@@ -8,6 +8,7 @@ import schedule
 
 # Internal Packages
 from khoj.processor.ledger.beancount_to_jsonl import BeancountToJsonl
+from khoj.processor.jsonl.jsonl_to_jsonl import JsonlToJsonl
 from khoj.processor.markdown.markdown_to_jsonl import MarkdownToJsonl
 from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
 from khoj.search_type import image_search, text_search
@@ -104,6 +105,18 @@ def configure_search(model: SearchModels, config: FullConfig, regenerate: bool, 
         model.image_search = image_search.setup(
             config.content_type.image, search_config=config.search_type.image, regenerate=regenerate
         )
+
+    # Initialize External Plugin Search
+    if (t == None or t in state.SearchType) and config.content_type.plugins:
+        model.plugin_search = {}
+        for plugin_type, plugin_config in config.content_type.plugins.items():
+            model.plugin_search[plugin_type] = text_search.setup(
+                JsonlToJsonl,
+                plugin_config,
+                search_config=config.search_type.asymmetric,
+                regenerate=regenerate,
+                filters=[DateFilter(), WordFilter(), FileFilter()],
+            )
 
     # Invalidate Query Cache
     state.query_cache = LRU()

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -63,7 +63,7 @@
         function search(rerank=false) {
             // Extract required fields for search from form
             query = document.getElementById("query").value.trim();
-            type = document.getElementById("type").value;
+            type = document.getElementById("type").value.toLowerCase();
             results_count = document.getElementById("results-count").value || 6;
             console.log(`Query: ${query}, Type: ${type}`);
 
@@ -116,21 +116,21 @@
         }
 
         function populate_type_dropdown() {
-            // Populate type dropdown field with enabled search types only
-            var possible_search_types = ["org", "markdown", "ledger", "music", "image"];
-            fetch("/api/config/data")
+            // Populate type dropdown field with enabled content types only
+            fetch("/api/config/types")
                 .then(response => response.json())
-                .then(data => {
+                .then(enabled_types => {
                     document.getElementById("type").innerHTML =
-                    possible_search_types
-                    .filter(type => data["content-type"].hasOwnProperty(type) && data["content-type"][type])
+                    enabled_types
                     .map(type => `<option value="${type}">${type.slice(0,1).toUpperCase() + type.slice(1)}</option>`)
                     .join('');
+
+                    return enabled_types;
                 })
-                .then(() => {
-                    // Set type field to search type passed in URL query parameter, if valid
+                .then(enabled_types => {
+                    // Set type field to content type passed in URL query parameter, if valid
                     var type_via_url = new URLSearchParams(window.location.search).get("t");
-                    if (type_via_url && possible_search_types.includes(type_via_url))
+                    if (type_via_url && enabled_types.includes(type_via_url))
                         document.getElementById("type").value = type_via_url;
                 });
         }
@@ -154,7 +154,7 @@
         }
 
         window.onload = function () {
-            // Dynamically populate type dropdown based on enabled search types and type passed as URL query parameter
+            // Dynamically populate type dropdown based on enabled content types and type passed as URL query parameter
             populate_type_dropdown();
 
             // Set results count field with value passed in URL query parameters, if any.

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -65,7 +65,7 @@
         function search(rerank=false) {
             // Extract required fields for search from form
             query = document.getElementById("query").value.trim();
-            type = document.getElementById("type").value.toLowerCase();
+            type = document.getElementById("type").value;
             results_count = document.getElementById("results-count").value || 6;
             console.log(`Query: ${query}, Type: ${type}`);
 

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -56,7 +56,9 @@
             } else if (type === "ledger") {
                 return render_ledger(query, data);
             } else {
-                return `<pre id="json">${JSON.stringify(data, null, 2)}</pre>`;
+                return `<div id="results-plugin">`
+                    + data.map((item) => `<p>${item.entry}</p>`).join("\n")
+                    + `</div>`;
             }
         }
 
@@ -277,9 +279,10 @@
         #json {
             white-space: pre-wrap;
         }
+        #results-plugin,
         #results-ledger {
-            white-space: pre-line;
             text-align: left;
+            white-space: pre-line;
         }
          #results-markdown {
             text-align: left;

--- a/src/khoj/main.py
+++ b/src/khoj/main.py
@@ -14,18 +14,14 @@ warnings.filterwarnings("ignore", message=r"legacy way to download files from th
 # External Packages
 import uvicorn
 from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
 from PyQt6 import QtWidgets
 from PyQt6.QtCore import QThread, QTimer
 from rich.logging import RichHandler
 import schedule
 
 # Internal Packages
-from khoj.configure import configure_server
-from khoj.routers.api import api
-from khoj.routers.api_beta import api_beta
-from khoj.routers.web_client import web_client
-from khoj.utils import constants, state
+from khoj.configure import configure_routes, configure_server
+from khoj.utils import state
 from khoj.utils.cli import cli
 from khoj.interface.desktop.main_window import MainWindow
 from khoj.interface.desktop.system_tray import create_system_tray
@@ -33,10 +29,6 @@ from khoj.interface.desktop.system_tray import create_system_tray
 
 # Initialize the Application Server
 app = FastAPI()
-app.mount("/static", StaticFiles(directory=constants.web_directory), name="static")
-app.include_router(api, prefix="/api")
-app.include_router(api_beta, prefix="/api/beta")
-app.include_router(web_client)
 
 # Setup Logger
 rich_handler = RichHandler(rich_tracebacks=True)
@@ -78,6 +70,7 @@ def run():
         poll_task_scheduler()
         # Start Server
         configure_server(args, required=False)
+        configure_routes(app)
         start_server(app, host=args.host, port=args.port, socket=args.socket)
     else:
         # Setup GUI
@@ -95,6 +88,7 @@ def run():
 
         # Setup Server
         configure_server(args, required=False)
+        configure_routes(app)
         server = ServerThread(app, args.host, args.port, args.socket)
 
         # Show Main Window on First Run Experience or if on Linux

--- a/src/khoj/processor/jsonl/jsonl_to_jsonl.py
+++ b/src/khoj/processor/jsonl/jsonl_to_jsonl.py
@@ -1,0 +1,100 @@
+# Standard Packages
+import glob
+import logging
+from pathlib import Path
+from typing import List
+
+# Internal Packages
+from khoj.processor.text_to_jsonl import TextToJsonl
+from khoj.utils.helpers import get_absolute_path, timer
+from khoj.utils.jsonl import load_jsonl, dump_jsonl, compress_jsonl_data
+from khoj.utils.rawconfig import Entry
+
+
+logger = logging.getLogger(__name__)
+
+
+class JsonlToJsonl(TextToJsonl):
+    # Define Functions
+    def process(self, previous_entries=None):
+        # Extract required fields from config
+        input_jsonl_files, input_jsonl_filter, output_file = (
+            self.config.input_files,
+            self.config.input_filter,
+            self.config.compressed_jsonl,
+        )
+
+        # Get Jsonl Input Files to Process
+        all_input_jsonl_files = JsonlToJsonl.get_jsonl_files(input_jsonl_files, input_jsonl_filter)
+
+        # Extract Entries from specified jsonl files
+        with timer("Parse entries from jsonl files", logger):
+            input_jsons = JsonlToJsonl.extract_jsonl_entries(all_input_jsonl_files)
+            current_entries = list(map(Entry.from_dict, input_jsons))
+
+        # Split entries by max tokens supported by model
+        with timer("Split entries by max token size supported by model", logger):
+            current_entries = self.split_entries_by_max_tokens(current_entries, max_tokens=256)
+
+        # Identify, mark and merge any new entries with previous entries
+        with timer("Identify new or updated entries", logger):
+            if not previous_entries:
+                entries_with_ids = list(enumerate(current_entries))
+            else:
+                entries_with_ids = self.mark_entries_for_update(
+                    current_entries,
+                    previous_entries,
+                    key="compiled",
+                    logger=logger,
+                )
+
+        with timer("Write entries to JSONL file", logger):
+            # Process Each Entry from All Notes Files
+            entries = list(map(lambda entry: entry[1], entries_with_ids))
+            jsonl_data = JsonlToJsonl.convert_entries_to_jsonl(entries)
+
+            # Compress JSONL formatted Data
+            if output_file.suffix == ".gz":
+                compress_jsonl_data(jsonl_data, output_file)
+            elif output_file.suffix == ".jsonl":
+                dump_jsonl(jsonl_data, output_file)
+
+        return entries_with_ids
+
+    @staticmethod
+    def get_jsonl_files(jsonl_files=None, jsonl_file_filters=None):
+        "Get all jsonl files to process"
+        absolute_jsonl_files, filtered_jsonl_files = set(), set()
+        if jsonl_files:
+            absolute_jsonl_files = {get_absolute_path(jsonl_file) for jsonl_file in jsonl_files}
+        if jsonl_file_filters:
+            filtered_jsonl_files = {
+                filtered_file
+                for jsonl_file_filter in jsonl_file_filters
+                for filtered_file in glob.glob(get_absolute_path(jsonl_file_filter), recursive=True)
+            }
+
+        all_jsonl_files = sorted(absolute_jsonl_files | filtered_jsonl_files)
+
+        files_with_non_jsonl_extensions = {
+            jsonl_file for jsonl_file in all_jsonl_files if not jsonl_file.endswith(".jsonl")
+        }
+        if any(files_with_non_jsonl_extensions):
+            print(f"[Warning] There maybe non jsonl files in the input set: {files_with_non_jsonl_extensions}")
+
+        logger.info(f"Processing files: {all_jsonl_files}")
+
+        return all_jsonl_files
+
+    @staticmethod
+    def extract_jsonl_entries(jsonl_files):
+        "Extract entries from specified jsonl files"
+        entries = []
+        for jsonl_file in jsonl_files:
+            entries.extend(load_jsonl(Path(jsonl_file)))
+        return entries
+
+    @staticmethod
+    def convert_entries_to_jsonl(entries: List[Entry]):
+        "Convert each entry to JSON and collate as JSONL"
+        return "".join([f"{entry.to_json()}\n" for entry in entries])

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -26,6 +26,17 @@ def get_default_config_data():
     return constants.default_config
 
 
+@api.get("/config/types", response_model=List[str])
+def get_config_types():
+    """Get configured content types"""
+    return [
+        search_type.name
+        for search_type in SearchType
+        if any(search_type.value == configured_content_type[0] for configured_content_type in state.config.content_type)
+        or search_type.value in state.config.content_type.plugins.keys()
+    ]
+
+
 @api.get("/config/data", response_model=FullConfig)
 def get_config_data():
     return state.config

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -30,10 +30,10 @@ def get_default_config_data():
 def get_config_types():
     """Get configured content types"""
     return [
-        search_type.name
+        search_type.value
         for search_type in SearchType
         if any(search_type.value == configured_content_type[0] for configured_content_type in state.config.content_type)
-        or search_type.value in state.config.content_type.plugins.keys()
+        or search_type.name in state.config.content_type.plugins.keys()
     ]
 
 

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -109,6 +109,20 @@ def search(q: str, n: Optional[int] = 5, t: Optional[SearchType] = None, r: Opti
                 count=results_count,
             )
 
+    elif (t in SearchType or t == None) and state.model.plugin_search:
+        # query specified plugin type
+        with timer("Query took", logger):
+            hits, entries = text_search.query(
+                user_query,
+                # Get plugin search model for specified search type, or the first one if none specified
+                state.model.plugin_search.get(t.value) or next(iter(state.model.plugin_search.values())),
+                rank_results=r,
+            )
+
+        # collate and return results
+        with timer("Collating results took", logger):
+            results = text_search.collate_results(hits, entries, results_count)
+
     # Cache results
     state.query_cache[query_cache_key] = results
 

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -12,9 +12,8 @@ from khoj.configure import configure_processor, configure_search
 from khoj.search_type import image_search, text_search
 from khoj.utils.helpers import timer
 from khoj.utils.rawconfig import FullConfig, SearchResponse
-from khoj.utils.config import SearchType
+from khoj.utils.state import SearchType
 from khoj.utils import state, constants
-
 
 # Initialize Router
 api = APIRouter()

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -32,7 +32,7 @@ def get_config_types():
     return [
         search_type.value
         for search_type in SearchType
-        if any(search_type.value == configured_content_type[0] for configured_content_type in state.config.content_type)
+        if any(search_type.value == ctype[0] and ctype[1] for ctype in state.config.content_type)
         or search_type.name in state.config.content_type.plugins.keys()
     ]
 

--- a/src/khoj/routers/api_beta.py
+++ b/src/khoj/routers/api_beta.py
@@ -17,7 +17,7 @@ from khoj.processor.conversation.gpt import (
     understand,
     summarize,
 )
-from khoj.utils.config import SearchType
+from khoj.utils.state import SearchType
 from khoj.utils.helpers import get_from_dict, resolve_absolute_path
 from khoj.utils import state
 

--- a/src/khoj/utils/config.py
+++ b/src/khoj/utils/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations  # to avoid quoting type hints
 from enum import Enum
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List
 
 # External Packages
 import torch
@@ -62,6 +62,7 @@ class SearchModels:
     music_search: TextSearchModel = None
     markdown_search: TextSearchModel = None
     image_search: ImageSearchModel = None
+    plugin_search: Dict[str, TextSearchModel] = None
 
 
 class ConversationProcessorConfigModel:

--- a/src/khoj/utils/rawconfig.py
+++ b/src/khoj/utils/rawconfig.py
@@ -1,7 +1,7 @@
 # System Packages
 import json
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Dict, Optional
 
 # External Packages
 from pydantic import BaseModel, validator
@@ -56,6 +56,7 @@ class ContentConfig(ConfigBase):
     image: Optional[ImageContentConfig]
     music: Optional[TextContentConfig]
     markdown: Optional[TextContentConfig]
+    plugins: Optional[Dict[str, TextContentConfig]]
 
 
 class TextSearchConfig(ConfigBase):

--- a/src/khoj/utils/state.py
+++ b/src/khoj/utils/state.py
@@ -8,6 +8,7 @@ import torch
 from pathlib import Path
 
 # Internal Packages
+from khoj.utils import config as utils_config
 from khoj.utils.config import SearchModels, ProcessorConfigModel
 from khoj.utils.helpers import LRU
 from khoj.utils.rawconfig import FullConfig
@@ -23,6 +24,7 @@ port: int = None
 cli_args: List[str] = None
 query_cache = LRU()
 search_index_lock = threading.Lock()
+SearchType = utils_config.SearchType
 
 if torch.cuda.is_available():
     # Use CUDA GPU

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 # External Packages
 from copy import deepcopy
+from fastapi.testclient import TestClient
 from pathlib import Path
 import pytest
 
 # Internal Packages
+from khoj.main import app
+from khoj.configure import configure_routes, configure_search_types
 from khoj.search_type import image_search, text_search
 from khoj.utils.helpers import resolve_absolute_path
 from khoj.utils.rawconfig import (
@@ -14,6 +17,7 @@ from khoj.utils.rawconfig import (
     TextSearchConfig,
     ImageSearchConfig,
 )
+from khoj.utils import state
 from khoj.processor.jsonl.jsonl_to_jsonl import JsonlToJsonl
 from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
 from khoj.search_filter.date_filter import DateFilter
@@ -87,6 +91,16 @@ def content_config(tmp_path_factory, search_config: SearchConfig):
     )
 
     return content_config
+
+
+@pytest.fixture(scope="session")
+def client(content_config: ContentConfig, search_config: SearchConfig):
+    state.config.content_type = content_config
+    state.config.search_type = search_config
+    state.SearchType = configure_search_types(state.config)
+
+    configure_routes(app)
+    return TestClient(app)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from khoj.utils.rawconfig import (
     TextSearchConfig,
     ImageSearchConfig,
 )
+from khoj.processor.jsonl.jsonl_to_jsonl import JsonlToJsonl
 from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
 from khoj.search_filter.date_filter import DateFilter
 from khoj.search_filter.word_filter import WordFilter
@@ -64,12 +65,26 @@ def content_config(tmp_path_factory, search_config: SearchConfig):
     content_config.org = TextContentConfig(
         input_files=None,
         input_filter=["tests/data/org/*.org"],
-        compressed_jsonl=content_dir.joinpath("notes.jsonl.gz"),
+        compressed_jsonl=content_dir.joinpath("notes.jsonl"),
         embeddings_file=content_dir.joinpath("note_embeddings.pt"),
     )
 
     filters = [DateFilter(), WordFilter(), FileFilter()]
     text_search.setup(OrgToJsonl, content_config.org, search_config.asymmetric, regenerate=False, filters=filters)
+
+    content_config.plugins = {
+        "plugin1": TextContentConfig(
+            input_files=[content_dir.joinpath("notes.jsonl")],
+            input_filter=None,
+            compressed_jsonl=content_dir.joinpath("plugin.jsonl.gz"),
+            embeddings_file=content_dir.joinpath("plugin_embeddings.pt"),
+        )
+    }
+
+    filters = [DateFilter(), WordFilter(), FileFilter()]
+    text_search.setup(
+        JsonlToJsonl, content_config.plugins["plugin1"], search_config.asymmetric, regenerate=False, filters=filters
+    )
 
     return content_config
 

--- a/tests/data/config.yml
+++ b/tests/data/config.yml
@@ -6,6 +6,17 @@ content-type:
     embeddings-file: ".note_embeddings.pt"
     index-header-entries: true
 
+  plugins:
+    content_plugin_1:
+      input-files: [ "content_plugin_1_new.jsonl.gz" ]
+      compressed-jsonl: "content_plugin_1.jsonl.gz"
+      embeddings-file: "content_plugin_1_embeddings.pt"
+
+    content_plugin_2:
+      input-filter: [ "*2_new.jsonl.gz" ]
+      compressed-jsonl: "content_plugin_2.jsonl.gz"
+      embeddings-file: "content_plugin_2_embeddings.pt"
+
 search-type:
   asymmetric:
     encoder: "sentence-transformers/msmarco-MiniLM-L-6-v3"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,8 +43,21 @@ def test_cli_config_from_file():
     assert actual_args.no_gui == True
     assert actual_args.regenerate == True
     assert actual_args.config is not None
+    assert actual_args.verbose == 3
+
+    # Ensure content config is loaded from file
     assert actual_args.config.content_type.org.input_files == [
         Path("~/first_from_config.org"),
         Path("~/second_from_config.org"),
     ]
-    assert actual_args.verbose == 3
+    assert len(actual_args.config.content_type.plugins.keys()) == 2
+    assert actual_args.config.content_type.plugins["content_plugin_1"].input_files == [
+        Path("content_plugin_1_new.jsonl.gz")
+    ]
+    assert actual_args.config.content_type.plugins["content_plugin_2"].input_filter == ["*2_new.jsonl.gz"]
+    assert actual_args.config.content_type.plugins["content_plugin_1"].compressed_jsonl == Path(
+        "content_plugin_1.jsonl.gz"
+    )
+    assert actual_args.config.content_type.plugins["content_plugin_2"].embeddings_file == Path(
+        "content_plugin_2_embeddings.pt"
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 # Internal Packages
 from khoj.main import app
 from khoj.configure import configure_routes
-from khoj.utils.state import model, config
+from khoj.utils.state import model
 from khoj.search_type import text_search, image_search
 from khoj.utils.rawconfig import ContentConfig, SearchConfig
 from khoj.processor.org_mode.org_to_jsonl import OrgToJsonl
@@ -18,15 +18,9 @@ from khoj.search_filter.word_filter import WordFilter
 from khoj.search_filter.file_filter import FileFilter
 
 
-# Arrange
-# ----------------------------------------------------------------------------------------------------
-configure_routes(app)
-client = TestClient(app)
-
-
 # Test
 # ----------------------------------------------------------------------------------------------------
-def test_search_with_invalid_content_type():
+def test_search_with_invalid_content_type(client):
     # Arrange
     user_query = quote("How to call Khoj from Emacs?")
 
@@ -38,13 +32,8 @@ def test_search_with_invalid_content_type():
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_search_with_valid_content_type(content_config: ContentConfig, search_config: SearchConfig):
-    # Arrange
-    config.content_type = content_config
-    config.search_type = search_config
-
-    # config.content_type.image = search_config.image
-    for content_type in ["org", "markdown", "ledger", "music"]:
+def test_search_with_valid_content_type(client):
+    for content_type in ["org", "markdown", "ledger", "music", "plugin1"]:
         # Act
         response = client.get(f"/api/search?q=random&t={content_type}")
         # Assert
@@ -52,7 +41,7 @@ def test_search_with_valid_content_type(content_config: ContentConfig, search_co
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_update_with_invalid_content_type():
+def test_update_with_invalid_content_type(client):
     # Act
     response = client.get(f"/api/update?t=invalid_content_type")
 
@@ -61,12 +50,8 @@ def test_update_with_invalid_content_type():
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_update_with_valid_content_type(content_config: ContentConfig, search_config: SearchConfig):
-    # Arrange
-    config.content_type = content_config
-    config.search_type = search_config
-
-    for content_type in ["org", "markdown", "ledger", "music"]:
+def test_update_with_valid_content_type(client):
+    for content_type in ["org", "markdown", "ledger", "music", "plugin1"]:
         # Act
         response = client.get(f"/api/update?t={content_type}")
         # Assert
@@ -74,7 +59,7 @@ def test_update_with_valid_content_type(content_config: ContentConfig, search_co
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_regenerate_with_invalid_content_type():
+def test_regenerate_with_invalid_content_type(client):
     # Act
     response = client.get(f"/api/update?force=true&t=invalid_content_type")
 
@@ -83,12 +68,8 @@ def test_regenerate_with_invalid_content_type():
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_regenerate_with_valid_content_type(content_config: ContentConfig, search_config: SearchConfig):
-    # Arrange
-    config.content_type = content_config
-    config.search_type = search_config
-
-    for content_type in ["org", "markdown", "ledger", "music", "image"]:
+def test_regenerate_with_valid_content_type(client):
+    for content_type in ["org", "markdown", "ledger", "music", "image", "plugin1"]:
         # Act
         response = client.get(f"/api/update?force=true&t={content_type}")
         # Assert
@@ -96,10 +77,8 @@ def test_regenerate_with_valid_content_type(content_config: ContentConfig, searc
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_image_search(content_config: ContentConfig, search_config: SearchConfig):
+def test_image_search(client, content_config: ContentConfig, search_config: SearchConfig):
     # Arrange
-    config.content_type = content_config
-    config.search_type = search_config
     model.image_search = image_search.setup(content_config.image, search_config.image, regenerate=False)
     query_expected_image_pairs = [
         ("kitten", "kitten_park.jpg"),
@@ -121,7 +100,7 @@ def test_image_search(content_config: ContentConfig, search_config: SearchConfig
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_notes_search(content_config: ContentConfig, search_config: SearchConfig):
+def test_notes_search(client, content_config: ContentConfig, search_config: SearchConfig):
     # Arrange
     model.orgmode_search = text_search.setup(OrgToJsonl, content_config.org, search_config.asymmetric, regenerate=False)
     user_query = quote("How to git install application?")
@@ -137,7 +116,7 @@ def test_notes_search(content_config: ContentConfig, search_config: SearchConfig
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_notes_search_with_only_filters(content_config: ContentConfig, search_config: SearchConfig):
+def test_notes_search_with_only_filters(client, content_config: ContentConfig, search_config: SearchConfig):
     # Arrange
     filters = [WordFilter(), FileFilter()]
     model.orgmode_search = text_search.setup(
@@ -156,7 +135,7 @@ def test_notes_search_with_only_filters(content_config: ContentConfig, search_co
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_notes_search_with_include_filter(content_config: ContentConfig, search_config: SearchConfig):
+def test_notes_search_with_include_filter(client, content_config: ContentConfig, search_config: SearchConfig):
     # Arrange
     filters = [WordFilter()]
     model.orgmode_search = text_search.setup(
@@ -175,7 +154,7 @@ def test_notes_search_with_include_filter(content_config: ContentConfig, search_
 
 
 # ----------------------------------------------------------------------------------------------------
-def test_notes_search_with_exclude_filter(content_config: ContentConfig, search_config: SearchConfig):
+def test_notes_search_with_exclude_filter(client, content_config: ContentConfig, search_config: SearchConfig):
     # Arrange
     filters = [WordFilter()]
     model.orgmode_search = text_search.setup(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 # Internal Packages
 from khoj.main import app
+from khoj.configure import configure_routes
 from khoj.utils.state import model, config
 from khoj.search_type import text_search, image_search
 from khoj.utils.rawconfig import ContentConfig, SearchConfig
@@ -19,6 +20,7 @@ from khoj.search_filter.file_filter import FileFilter
 
 # Arrange
 # ----------------------------------------------------------------------------------------------------
+configure_routes(app)
 client = TestClient(app)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,6 +77,16 @@ def test_regenerate_with_valid_content_type(client):
 
 
 # ----------------------------------------------------------------------------------------------------
+def test_get_configured_types_via_api(client):
+    # Act
+    response = client.get(f"/api/config/types")
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == ["org", "image", "plugin1"]
+
+
+# ----------------------------------------------------------------------------------------------------
 def test_image_search(client, content_config: ContentConfig, search_config: SearchConfig):
     # Arrange
     model.image_search = image_search.setup(content_config.image, search_config.image, regenerate=False)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ def test_search_with_invalid_content_type(client):
 
 # ----------------------------------------------------------------------------------------------------
 def test_search_with_valid_content_type(client):
-    for content_type in ["org", "markdown", "ledger", "music", "plugin1"]:
+    for content_type in ["org", "markdown", "ledger", "image", "music", "plugin1"]:
         # Act
         response = client.get(f"/api/search?q=random&t={content_type}")
         # Assert
@@ -51,7 +51,7 @@ def test_update_with_invalid_content_type(client):
 
 # ----------------------------------------------------------------------------------------------------
 def test_update_with_valid_content_type(client):
-    for content_type in ["org", "markdown", "ledger", "music", "plugin1"]:
+    for content_type in ["org", "markdown", "ledger", "image", "music", "plugin1"]:
         # Act
         response = client.get(f"/api/update?t={content_type}")
         # Assert
@@ -69,7 +69,7 @@ def test_regenerate_with_invalid_content_type(client):
 
 # ----------------------------------------------------------------------------------------------------
 def test_regenerate_with_valid_content_type(client):
-    for content_type in ["org", "markdown", "ledger", "music", "image", "plugin1"]:
+    for content_type in ["org", "markdown", "ledger", "image", "music", "plugin1"]:
         # Act
         response = client.get(f"/api/update?force=true&t={content_type}")
         # Assert

--- a/tests/test_jsonl_to_jsonl.py
+++ b/tests/test_jsonl_to_jsonl.py
@@ -1,0 +1,82 @@
+# Standard Packages
+import json
+
+# Internal Packages
+from khoj.processor.jsonl.jsonl_to_jsonl import JsonlToJsonl
+from khoj.utils.jsonl import load_jsonl
+from khoj.utils.rawconfig import Entry
+
+
+def test_process_entries_from_single_input_jsonl(tmp_path):
+    "Convert multiple jsonl entries from single file to entries."
+    # Arrange
+    input_jsonl = """{"raw": "raw input data 1", "compiled": "compiled input data 1", "file": "source/file/path1"}
+{"raw": "raw input data 2", "compiled": "compiled input data 2", "file": "source/file/path2"}
+"""
+    input_jsonl_file = create_file(tmp_path, input_jsonl)
+
+    # Act
+    # Process Each Entry from All Notes Files
+    input_jsons = JsonlToJsonl.extract_jsonl_entries([input_jsonl_file])
+    entries = list(map(Entry.from_dict, input_jsons))
+    output_jsonl = JsonlToJsonl.convert_entries_to_jsonl(entries)
+
+    # Assert
+    assert len(entries) == 2
+    assert output_jsonl == input_jsonl
+
+
+def test_process_entries_from_multiple_input_jsonls(tmp_path):
+    "Convert multiple jsonl entries from single file to entries."
+    # Arrange
+    input_jsonl_1 = """{"raw": "raw input data 1", "compiled": "compiled input data 1", "file": "source/file/path1"}"""
+    input_jsonl_2 = """{"raw": "raw input data 2", "compiled": "compiled input data 2", "file": "source/file/path2"}"""
+    input_jsonl_file_1 = create_file(tmp_path, input_jsonl_1, filename="input1.jsonl")
+    input_jsonl_file_2 = create_file(tmp_path, input_jsonl_2, filename="input2.jsonl")
+
+    # Act
+    # Process Each Entry from All Notes Files
+    input_jsons = JsonlToJsonl.extract_jsonl_entries([input_jsonl_file_1, input_jsonl_file_2])
+    entries = list(map(Entry.from_dict, input_jsons))
+    output_jsonl = JsonlToJsonl.convert_entries_to_jsonl(entries)
+
+    # Assert
+    assert len(entries) == 2
+    assert output_jsonl == f"{input_jsonl_1}\n{input_jsonl_2}\n"
+
+
+def test_get_jsonl_files(tmp_path):
+    "Ensure JSONL files specified via input-filter, input-files extracted"
+    # Arrange
+    # Include via input-filter globs
+    group1_file1 = create_file(tmp_path, filename="group1-file1.jsonl")
+    group1_file2 = create_file(tmp_path, filename="group1-file2.jsonl")
+    group2_file1 = create_file(tmp_path, filename="group2-file1.jsonl")
+    group2_file2 = create_file(tmp_path, filename="group2-file2.jsonl")
+    # Include via input-file field
+    file1 = create_file(tmp_path, filename="notes.jsonl")
+    # Not included by any filter
+    create_file(tmp_path, filename="not-included-jsonl.jsonl")
+    create_file(tmp_path, filename="not-included-text.txt")
+
+    expected_files = sorted(map(str, [group1_file1, group1_file2, group2_file1, group2_file2, file1]))
+
+    # Setup input-files, input-filters
+    input_files = [tmp_path / "notes.jsonl"]
+    input_filter = [tmp_path / "group1*.jsonl", tmp_path / "group2*.jsonl"]
+
+    # Act
+    extracted_org_files = JsonlToJsonl.get_jsonl_files(input_files, input_filter)
+
+    # Assert
+    assert len(extracted_org_files) == 5
+    assert extracted_org_files == expected_files
+
+
+# Helper Functions
+def create_file(tmp_path, entry=None, filename="test.jsonl"):
+    jsonl_file = tmp_path / filename
+    jsonl_file.touch()
+    if entry:
+        jsonl_file.write_text(entry)
+    return jsonl_file


### PR DESCRIPTION
### Goal
Index, Search text content not supported by default in Khoj using plugins

### Usage

1. Create content plugin. It should render the source content into standardized JSONL format expected by Khoj
   - JSONL is just a list of json objects separated by newline
   - For khoj, each json line contains data about an entry to be indexed. E.g a markdown heading
   - Each json object needs `raw`, `compiled` and `file` keys.
      - The `raw` value is rendered as the search result in the interfaces 
      - The `compiled` values are used to generate embeddings for search
      - The `file` key can be used to jump to the result in its source file from the interfaces
2. Configure `khoj.yml` to point to the location of the plugin generated jsonl via the `input-files`, `input-filter` fields. See `tests/data/config.yml`. This is done on user machine either via code or by user manually updating their `khoj.yml` file
   ```diff
   @@ -6,6 +6,17 @@ content-type:
       embeddings-file: ".note_embeddings.pt"
       index-header-entries: true
   
   +  plugins:
   +    content_plugin_1:
   +      input-files: [ "content_plugin_1_new.jsonl" ]
   +      compressed-jsonl: "content_plugin_1.jsonl.gz"
   +      embeddings-file: "content_plugin_1_embeddings.pt"
   +
   +    content_plugin_2:
   +      input-filter: [ "*2_new.jsonl" ]
   +      compressed-jsonl: "content_plugin_2.jsonl.gz"
   +      embeddings-file: "content_plugin_2_embeddings.pt"
   
   search-type:
     asymmetric:
       encoder: "sentence-transformers/msmarco-MiniLM-L-6-v3"
   ```
3. Index plugin content by triggering update from interfaces, (re-)starting khoj server or calling `/api/update?t=<plugin-name>` API endpoint
4. Just set search type to the plugin via interface menu before searching via the web or Emacs interface as usual

### Code Changes
- fcbbe8c Configure content plugins to index using `khoj.yml`
- Index content plugins from standardized JSONL format for ingestion
  - 55a032e Add jsonl processor to index plugin content
  - ab0d3a0 Index configured plugins on app start and via update API endpoint
- Expose plugin content types for usage by interfaces
  - 47b58a2 Dynamically update available types on loading the Khoj server
  - Expose indexed types via API (9d38ead). Simplify getting enabled types in Web (f3f2438), Emacs (1e43f1a) interfaces
- Search plugin content from the Web and Emacs Interfaces
  - d91c7e2 Search plugin content via the search API
  - Render plugin content on Web (88344f9) and Emacs (c2814fc) interfaces
    - The Web, Emacs interfaces are general interfaces, they allow searching across all content types
    - The Obsidian interface is currently tuned for only markdown content
      It will be extended to render more content plugins later

### Testing
- fcbbe8c Add unit tests to test reading plugin config from khoj.yml
- 55a032e Add unit tests for the `JsonlToJsonl` processor
- 88a9ead Add unit tests to validate search, incremental update, force-update API works with plugin content types
- b09350c Add unit test to validate only configure search types returned by the new /api/config/types API endpoint
- Manually test the config read, indexing, search and update with local khoj