### PR TITLE
Create Khoj Chat Interface in Emacs

### DIFF
--- a/.github/workflows/test_khoj_el.yml
+++ b/.github/workflows/test_khoj_el.yml
@@ -42,7 +42,10 @@ jobs:
                     (push '(\"melpa\" . \"https://melpa.org/packages/\") package-archives) \
                     (package-initialize) \
                     (unless package-archive-contents (package-refresh-contents)) \
-                    (unless (package-installed-p 'transient) (package-install 'transient)))" \
+                    (unless (package-installed-p 'transient) (package-install 'transient)) \
+                    (unless (package-installed-p 'dash) (package-install 'dash)) \
+                    (unless (package-installed-p 'org) (package-install 'org)) \
+                   )" \
            -l ert \
            -l ./src/interface/emacs/khoj.el \
            -l ./src/interface/emacs/tests/khoj-tests.el \

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -6,7 +6,7 @@
 ;; Description: Natural, Incremental Search for your Second Brain
 ;; Keywords: search, org-mode, outlines, markdown, beancount, ledger, image
 ;; Version: 0.4.1
-;; Package-Requires: ((emacs "27.1") (transient "0.3.0") (dash "2.19.1") (org "9.0.0"))
+;; Package-Requires: ((emacs "27.1") (transient "0.3.0") (dash "2.19.1"))
 ;; URL: https://github.com/debanjum/khoj/tree/master/src/interface/emacs
 
 ;; This file is NOT part of GNU Emacs.
@@ -287,7 +287,7 @@ Use `which-key` if available, else display simple message in echo area"
       (url-insert-file-contents config-url)
       (thread-last
         (json-parse-buffer :object-type 'alist)
-        (mapcar 'intern)))))
+        (mapcar #'intern)))))
 
 (defun khoj--construct-search-api-query (query content-type &optional rerank)
   "Construct Search API Query.
@@ -349,7 +349,7 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
         ;; generate chat messages from Khoj Chat API response
         (mapcar #'khoj--render-chat-response)
         ;; insert chat messages into Khoj Chat Buffer
-        (mapcar #'insert))
+        (mapc #'insert))
       (progn (org-mode)
              (visual-line-mode)
              (read-only-mode t)))))
@@ -389,7 +389,7 @@ RECEIVE-DATE is the message receive date."
         (rest-message-lines (string-join (cdr (split-string message "\n" t)) "\n   "))
         (heading-level (if (equal sender "you") "**" "***"))
         (emojified-by (if (equal sender "you") "🤔 *You*" "🦅 *Khoj*"))
-        (received (or receive-date (format-time-string "%Y-%m-%d %H:%M:%S"))))
+        (received (or receive-date (format-time-string "%F %T"))))
     (format "%s %s: %s\n   :PROPERTIES:\n   :RECEIVED: [%s]\n   :END:\n   %s\n"
             heading-level
             emojified-by
@@ -605,7 +605,7 @@ Paragraph only starts at first text after blank line."
       (setq khoj--content-type content-type)
       (url-retrieve update-url (lambda (_) (message "Khoj %s index %supdated!" content-type (if (member "--force-update" args) "force " "")))))))
 
-(transient-define-suffix khoj--chat-command (&optional args)
+(transient-define-suffix khoj--chat-command (&optional _)
   "Command to Chat with Khoj."
   (interactive (list (transient-args transient-current-command)))
   (khoj--chat))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -6,7 +6,7 @@
 ;; Description: Natural, Incremental Search for your Second Brain
 ;; Keywords: search, org-mode, outlines, markdown, beancount, ledger, image
 ;; Version: 0.4.1
-;; Package-Requires: ((emacs "27.1") (transient "0.3.0") (dash "2.19.1")
+;; Package-Requires: ((emacs "27.1") (transient "0.3.0") (dash "2.19.1") (org "9.0.0"))
 ;; URL: https://github.com/debanjum/khoj/tree/master/src/interface/emacs
 
 ;; This file is NOT part of GNU Emacs.
@@ -51,6 +51,8 @@
 (require 'transient)
 (require 'outline)
 (require 'dash)
+(require 'org)
+
 (eval-when-compile (require 'subr-x)) ;; for string-trim before Emacs 28.2
 
 
@@ -372,7 +374,12 @@ RECEIVE-DATE is the message receive date."
 
 (defun khoj--generate-reference (index reference)
   "Create `org-mode' links with REFERENCE as link and INDEX as link description."
-  (format "[[[%s][%s]]]" (format "%s" reference) (format "%s" index)))
+  (with-temp-buffer
+    (org-insert-link
+     nil
+     (format "%s" (replace-regexp-in-string "\n" " " reference))
+     (format "%s" index))
+    (format "[%s]" (buffer-substring-no-properties (point-min) (point-max)))))
 
 (defun khoj--render-chat-response (json-response)
   "Render chat message using JSON-RESPONSE from Khoj Chat API."

--- a/src/interface/emacs/tests/khoj-tests.el
+++ b/src/interface/emacs/tests/khoj-tests.el
@@ -4,7 +4,7 @@
 
 ;; Author: Debanjum Singh Solanky <debanjum@gmail.com>
 ;; Version: 0.0.0
-;; Package-Requires: ((emacs "27.1") (transient "0.3.0"))
+;; Package-Requires: ((emacs "27.1") (transient "0.3.0") (dash "2.19.1") (org "9.0.0"))
 ;; URL: https://github.com/debanjum/khoj/tree/master/src/interface/emacs
 
 ;;; License:
@@ -28,8 +28,10 @@
 
 ;;; Code:
 
+(require 'dash)
 (require 'ert)
 (require 'khoj)
+(require 'org)
 
 
 


### PR DESCRIPTION
- Render conversation history in a read-only org-mode buffer for Khoj Chat
- Add `chat` as a transient action in the Khoj transient menu
- Style chat messages as org-mode entries
  - Put received date in property drawer and keep it hidden/folded by default
  - Add Khoj chat response as child entry of the users associated question org entry
    This allows folding back-n-forth between user and Khoj for easier viewing
  - Render source notes snippets used as references for response as org-mode links
    Hovering mouse on link or opening links shows reference note snippets used