### PR TITLE
Improve Khoj Chat in Emacs, Server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "fastapi == 0.77.1",
     "jinja2 == 3.1.2",
     "openai >= 0.27.0",
+    "tiktoken >= 0.3.0",
     "pillow == 9.3.0",
     "pydantic == 1.9.1",
     "pyqt6 == 6.3.1",

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -109,6 +109,8 @@
 (defvar khoj--content-type "org"
   "The type of content to perform search on.")
 
+(declare-function org-element-property "org-mode" (PROPERTY ELEMENT))
+(declare-function org-element-type "org-mode" (ELEMENT))
 (declare-function beancount-mode "beancount" ())
 (declare-function markdown-mode "markdown-mode" ())
 (declare-function org-music-mode "org-music" ())
@@ -345,6 +347,7 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
       (khoj--query-chat-api-and-render-messages query khoj--chat-buffer-name))))
 
 (defun khoj--load-chat-history (buffer-name)
+  "Load Khoj Chat conversation history into BUFFER-NAME."
   (let ((json-response (cdr (assoc 'response (khoj--query-chat-api "")))))
     (with-current-buffer (get-buffer-create buffer-name)
       (erase-buffer)
@@ -366,7 +369,7 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
              (read-only-mode t)))))
 
 (defun khoj--add-hover-text-to-footnote-refs (start-pos)
-  "Show footnote definition on mouse hover over all footnote references from START-POS."
+  "Show footnote defs on mouse hover on footnote refs from START-POS."
   (org-with-wide-buffer
    (goto-char start-pos)
    (while (re-search-forward org-footnote-re nil t)
@@ -382,8 +385,11 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
                    '(footnote-reference))
          (-->
           footnote-def
+          ;; truncate footnote definition if required
           (substring it 0 footnote-width)
+          ;; append continuation suffix if truncated
           (concat it (if footnote-width "..." ""))
+          ;; show definition on hover on footnote reference
           (overlay-put overlay 'help-echo it)))))))
 
 (defun khoj--query-chat-api-and-render-messages (query buffer-name)
@@ -399,9 +405,10 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
        (khoj--render-chat-message query "you" query-time)
        (khoj--render-chat-response json-response))
       (khoj--add-hover-text-to-footnote-refs new-content-start-pos))
-    (progn (org-mode)
-           (visual-line-mode))
-    (read-only-mode t)))
+    (progn
+      (org-set-startup-visibility)
+      (visual-line-mode)
+      (re-search-backward "^\*+ 🦅" nil t))))
 
 (defun khoj--query-chat-api (query)
   "Send QUERY to Khoj Chat API."
@@ -454,12 +461,12 @@ RECEIVE-DATE is the message receive date."
     (thread-first
       ;; concatenate khoj message and references from API
       (concat
-       ;; extract khoj message from API response and make it bold
        message
        ;; append reference links to khoj message
        (string-join footnote-links "")
        ;; append reference sub-section to khoj message and fold it
        (if footnote-defs "\n**** References\n:PROPERTIES:\n:VISIBILITY: folded\n:END:" "")
+       ;; append reference definitions to references subsection
        (string-join footnote-defs " "))
       ;; Render chat message using data obtained from API
       (khoj--render-chat-message sender receive-date))))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -443,9 +443,8 @@ RECEIVE-DATE is the message receive date."
   (let* ((message (cdr (or (assoc 'response json-response) (assoc 'message json-response))))
          (sender (cdr (assoc 'by json-response)))
          (receive-date (cdr (assoc 'created json-response)))
-         (context (or (cdr (assoc 'context json-response)) ""))
-         (reference-source-texts (split-string context "\n\n# " t))
-         (footnotes (mapcar #'khoj--generate-reference reference-source-texts))
+         (references (or (cdr (assoc 'context json-response)) '()))
+         (footnotes (mapcar #'khoj--generate-reference references))
          (footnote-links (mapcar #'car footnotes))
          (footnote-defs (mapcar #'cdr footnotes)))
     (thread-first

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -363,10 +363,11 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
   ;; render json response into formatted chat messages
   (with-current-buffer (get-buffer buffer-name)
     (let ((inhibit-read-only t)
+          (query-time (format-time-string "%F %T"))
           (json-response (khoj--query-chat-api query)))
       (goto-char (point-max))
       (insert
-       (khoj--render-chat-message query "you")
+       (khoj--render-chat-message query "you" query-time)
        (khoj--render-chat-response json-response)))
     (progn (org-mode)
            (visual-line-mode))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -417,14 +417,16 @@ RECEIVE-DATE is the message receive date."
   (let ((first-message-line (car (split-string message "\n" t)))
         (rest-message-lines (string-join (cdr (split-string message "\n" t)) "\n"))
         (heading-level (if (equal sender "you") "**" "***"))
-        (emojified-by (if (equal sender "you") "🤔 *You*" "🦅 *Khoj*"))
+        (emojified-sender (if (equal sender "you") "🤔 *You*" "🦅 *Khoj*"))
+        (suffix-newlines (if (equal sender "khoj") "\n\n" ""))
         (received (or receive-date (format-time-string "%F %T"))))
-    (format "%s %s: %s\n   :PROPERTIES:\n   :RECEIVED: [%s]\n   :END:\n%s\n"
+    (format "%s %s: %s\n   :PROPERTIES:\n   :RECEIVED: [%s]\n   :END:\n%s\n%s"
             heading-level
-            emojified-by
+            emojified-sender
             first-message-line
             received
-            rest-message-lines)))
+            rest-message-lines
+            suffix-newlines)))
 
 (defun khoj--generate-reference (reference)
   "Create `org-mode' footnotes with REFERENCE."
@@ -447,13 +449,15 @@ RECEIVE-DATE is the message receive date."
          (footnote-links (mapcar #'car footnotes))
          (footnote-defs (mapcar #'cdr footnotes)))
     (thread-first
-      ;; extract khoj message from API response and make it bold
-      (format "%s" message)
-      ;; append reference links to khoj message
-      (concat (string-join footnote-links ""))
-      ;; append reference sub-section to khoj message
-      (concat (if footnote-defs "\n**** References\n:PROPERTIES:\n:VISIBILITY: folded\n:END:" ""))
-      (concat (string-join footnote-defs " "))
+      ;; concatenate khoj message and references from API
+      (concat
+       ;; extract khoj message from API response and make it bold
+       message
+       ;; append reference links to khoj message
+       (string-join footnote-links "")
+       ;; append reference sub-section to khoj message and fold it
+       (if footnote-defs "\n**** References\n:PROPERTIES:\n:VISIBILITY: folded\n:END:" "")
+       (string-join footnote-defs " "))
       ;; Render chat message using data obtained from API
       (khoj--render-chat-message sender receive-date))))
 

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -134,7 +134,7 @@ NO-PAGING FILTER))
        "C-x M  | music\n"))))
 
 (defvar khoj--rerank nil "Track when re-rank of results triggered.")
-(defvar khoj--reference-count 0 "Track number of references current inserted into chat bufffer.")
+(defvar khoj--reference-count 0 "Track number of references currently in chat bufffer.")
 (defun khoj--search-markdown () "Set content-type to `markdown'." (interactive) (setq khoj--content-type "markdown"))
 (defun khoj--search-org () "Set content-type to `org-mode'." (interactive) (setq khoj--content-type "org"))
 (defun khoj--search-ledger () "Set content-type to `ledger'." (interactive) (setq khoj--content-type "ledger"))
@@ -336,6 +336,7 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
 
 (defun khoj--chat ()
   "Chat with Khoj."
+  (interactive)
   (when (not (get-buffer khoj--chat-buffer-name))
       (khoj--load-chat-history khoj--chat-buffer-name))
   (switch-to-buffer khoj--chat-buffer-name)
@@ -359,6 +360,9 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
       (progn (org-mode)
              (visual-line-mode)
              (khoj--add-hover-text-to-footnote-refs (point-min))
+             (use-local-map (copy-keymap org-mode-map))
+             (local-set-key (kbd "m") #'khoj--chat)
+             (local-set-key (kbd "C-x m") #'khoj--chat)
              (read-only-mode t)))))
 
 (defun khoj--add-hover-text-to-footnote-refs (start-pos)

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -39,7 +39,6 @@
             let references = '';
             if (context) {
                 references = context
-                    .split("\n\n# ")
                     .map((reference, index) => generateReference(reference, index))
                     .join("<sup>,</sup>");
             }

--- a/src/khoj/processor/conversation/gpt.py
+++ b/src/khoj/processor/conversation/gpt.py
@@ -247,6 +247,7 @@ Question: {user_query}"""
         conversation_primer,
         personality_primer,
         conversation_log,
+        model,
     )
 
     # Get Response from GPT

--- a/src/khoj/processor/conversation/gpt.py
+++ b/src/khoj/processor/conversation/gpt.py
@@ -223,13 +223,14 @@ A:{ "search-type": "notes" }"""
     return json.loads(story.strip(empty_escape_sequences))
 
 
-def converse(text, user_query, conversation_log={}, api_key=None, temperature=0.2):
+def converse(references, user_query, conversation_log={}, api_key=None, temperature=0.2):
     """
     Converse with user using OpenAI's ChatGPT
     """
     # Initialize Variables
     model = "gpt-3.5-turbo"
     openai.api_key = api_key or os.getenv("OPENAI_API_KEY")
+    compiled_references = "\n\n".join({f"# {item}" for item in references})
 
     personality_primer = "You are Khoj, a friendly, smart and helpful personal assistant."
     conversation_primer = f"""
@@ -237,7 +238,7 @@ Using the notes and our past conversations as context, answer the following ques
 Current Date: {datetime.now().strftime("%Y-%m-%d")}
 
 Notes:
-{text}
+{compiled_references}
 
 Question: {user_query}"""
 

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -38,20 +38,20 @@ def message_to_prompt(
     return f"{conversation_history}{restart_sequence} {user_message}{start_sequence}{gpt_message}"
 
 
-def message_to_log(user_message, gpt_message, khoj_message_metadata={}, conversation_log=[]):
+def message_to_log(user_message, gpt_message, user_message_metadata={}, khoj_message_metadata={}, conversation_log=[]):
     """Create json logs from messages, metadata for conversation log"""
     default_khoj_message_metadata = {
         "intent": {"type": "remember", "memory-type": "notes", "query": user_message},
         "trigger-emotion": "calm",
     }
-    current_dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    khoj_response_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     # Create json log from Human's message
-    human_log = {"message": user_message, "by": "you", "created": current_dt}
+    human_log = merge_dicts({"message": user_message, "by": "you"}, user_message_metadata)
 
     # Create json log from GPT's response
     khoj_log = merge_dicts(khoj_message_metadata, default_khoj_message_metadata)
-    khoj_log = merge_dicts({"message": gpt_message, "by": "khoj", "created": current_dt}, khoj_log)
+    khoj_log = merge_dicts({"message": gpt_message, "by": "khoj", "created": khoj_response_time}, khoj_log)
 
     conversation_log.extend([human_log, khoj_log])
     return conversation_log

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -215,11 +215,11 @@ def chat(q: Optional[str] = None):
         result_list = []
         for query in inferred_queries:
             result_list.extend(search(query, n=5, r=True, score_threshold=-5.0, dedupe=False))
-        collated_result = "\n\n".join({f"# {item.additional['compiled']}" for item in result_list})
+        compiled_references = [item.additional["compiled"] for item in result_list]
 
     try:
         with timer("Generating chat response took", logger):
-            gpt_response = converse(collated_result, q, meta_log, api_key=api_key)
+            gpt_response = converse(compiled_references, q, meta_log, api_key=api_key)
         status = "ok"
     except Exception as e:
         gpt_response = str(e)
@@ -231,8 +231,8 @@ def chat(q: Optional[str] = None):
         q,
         gpt_response,
         user_message_metadata={"created": user_message_time},
-        khoj_message_metadata={"context": collated_result, "intent": {"inferred-queries": inferred_queries}},
+        khoj_message_metadata={"context": compiled_references, "intent": {"inferred-queries": inferred_queries}},
         conversation_log=meta_log.get("chat", []),
     )
 
-    return {"status": status, "response": gpt_response, "context": collated_result}
+    return {"status": status, "response": gpt_response, "context": compiled_references}

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -2,6 +2,7 @@
 import math
 import yaml
 import logging
+from datetime import datetime
 from typing import List, Optional, Union
 
 # External Packages
@@ -192,6 +193,7 @@ def chat(q: Optional[str] = None):
     # Initialize Variables
     api_key = state.processor_config.conversation.openai_api_key
     model = state.processor_config.conversation.model
+    user_message_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     # Load Conversation History
     chat_session = state.processor_config.conversation.chat_session
@@ -225,6 +227,7 @@ def chat(q: Optional[str] = None):
     state.processor_config.conversation.meta_log["chat"] = message_to_log(
         q,
         gpt_response,
+        user_message_metadata={"created": user_message_time},
         khoj_message_metadata={"context": collated_result, "intent": {"inferred-queries": inferred_queries}},
         conversation_log=meta_log.get("chat", []),
     )

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -207,16 +207,19 @@ def chat(q: Optional[str] = None):
             return {"status": "ok", "response": []}
 
     # Infer search queries from user message
-    inferred_queries = extract_questions(q, model=model, api_key=api_key, conversation_log=meta_log)
+    with timer("Extracting search queries took", logger):
+        inferred_queries = extract_questions(q, model=model, api_key=api_key, conversation_log=meta_log)
 
     # Collate search results as context for GPT
-    result_list = []
-    for query in inferred_queries:
-        result_list.extend(search(query, n=5, r=True, score_threshold=-5.0, dedupe=False))
-    collated_result = "\n\n".join({f"# {item.additional['compiled']}" for item in result_list})
+    with timer("Searching knowledge base took", logger):
+        result_list = []
+        for query in inferred_queries:
+            result_list.extend(search(query, n=5, r=True, score_threshold=-5.0, dedupe=False))
+        collated_result = "\n\n".join({f"# {item.additional['compiled']}" for item in result_list})
 
     try:
-        gpt_response = converse(collated_result, q, meta_log, api_key=api_key)
+        with timer("Generating chat response took", logger):
+            gpt_response = converse(collated_result, q, meta_log, api_key=api_key)
         status = "ok"
     except Exception as e:
         gpt_response = str(e)

--- a/tests/test_chat_actors.py
+++ b/tests/test_chat_actors.py
@@ -111,7 +111,7 @@ def test_extract_multiple_implicit_questions_from_message():
 def test_generate_search_query_using_question_from_chat_history():
     # Arrange
     message_list = [
-        ("What is the name of Mr. Vaders daughter?", "Princess Leia", ""),
+        ("What is the name of Mr. Vader's daughter?", "Princess Leia", []),
     ]
 
     # Act
@@ -127,7 +127,7 @@ def test_generate_search_query_using_question_from_chat_history():
 def test_generate_search_query_using_answer_from_chat_history():
     # Arrange
     message_list = [
-        ("What is the name of Mr. Vaders daughter?", "Princess Leia", ""),
+        ("What is the name of Mr. Vader's daughter?", "Princess Leia", []),
     ]
 
     # Act
@@ -143,7 +143,7 @@ def test_generate_search_query_using_answer_from_chat_history():
 def test_generate_search_query_using_question_and_answer_from_chat_history():
     # Arrange
     message_list = [
-        ("Does Luke Skywalker have any Siblings?", "Yes, Princess Leia", ""),
+        ("Does Luke Skywalker have any Siblings?", "Yes, Princess Leia", []),
     ]
 
     # Act
@@ -159,7 +159,7 @@ def test_generate_search_query_using_question_and_answer_from_chat_history():
 def test_generate_search_query_with_date_and_context_from_chat_history():
     # Arrange
     message_list = [
-        ("When did I visit Masai Mara?", "You visited Masai Mara in April 2000", ""),
+        ("When did I visit Masai Mara?", "You visited Masai Mara in April 2000", []),
     ]
 
     # Act
@@ -184,7 +184,7 @@ def test_generate_search_query_with_date_and_context_from_chat_history():
 def test_chat_with_no_chat_history_or_retrieved_content():
     # Act
     response = converse(
-        text="",  # Assume no context retrieved from notes for the user_query
+        references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Hello, my name is Testatron. Who are you?",
         api_key=api_key,
     )
@@ -202,13 +202,13 @@ def test_chat_with_no_chat_history_or_retrieved_content():
 def test_answer_from_chat_history_and_no_content():
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
     ]
 
     # Act
     response = converse(
-        text="",  # Assume no context retrieved from notes for the user_query
+        references=[],  # Assume no context retrieved from notes for the user_query
         user_query="What is my name?",
         conversation_log=populate_chat_history(message_list),
         api_key=api_key,
@@ -228,13 +228,17 @@ def test_answer_from_chat_history_and_previously_retrieved_content():
     "Chat actor needs to use context in previous notes and chat history to answer question"
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", "Testatron was born on 1st April 1984 in Testville."),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        (
+            "When was I born?",
+            "You were born on 1st April 1984.",
+            ["Testatron was born on 1st April 1984 in Testville."],
+        ),
     ]
 
     # Act
     response = converse(
-        text="",  # Assume no context retrieved from notes for the user_query
+        references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
         api_key=api_key,
@@ -252,13 +256,15 @@ def test_answer_from_chat_history_and_currently_retrieved_content():
     "Chat actor needs to use context across currently retrieved notes and chat history to answer question"
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
     ]
 
     # Act
     response = converse(
-        text="Testatron was born on 1st April 1984 in Testville.",  # Assume context retrieved from notes for the user_query
+        references=[
+            "Testatron was born on 1st April 1984 in Testville."
+        ],  # Assume context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
         api_key=api_key,
@@ -275,13 +281,13 @@ def test_no_answer_in_chat_history_or_retrieved_content():
     "Chat actor should say don't know as not enough contexts in chat history or retrieved to answer question"
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
     ]
 
     # Act
     response = converse(
-        text="",  # Assume no context retrieved from notes for the user_query
+        references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Where was I born?",
         conversation_log=populate_chat_history(message_list),
         api_key=api_key,
@@ -300,23 +306,20 @@ def test_no_answer_in_chat_history_or_retrieved_content():
 def test_answer_requires_current_date_awareness():
     "Chat actor should be able to answer questions relative to current date using provided notes"
     # Arrange
-    context = f"""
-    # {datetime.now().strftime("%Y-%m-%d")} "Naco Taco" "Tacos for Dinner"
-      Expenses:Food:Dining  10.00 USD
-
-    # {datetime.now().strftime("%Y-%m-%d")} "Sagar Ratna" "Dosa for Lunch"
-      Expenses:Food:Dining  10.00 USD
-
-    # 2020-04-01 "SuperMercado" "Bananas"
-      Expenses:Food:Groceries  10.00 USD
-
-    # 2020-01-01 "Naco Taco" "Burittos for Dinner"
-      Expenses:Food:Dining  10.00 USD
-    """
+    context = [
+        f"""{datetime.now().strftime("%Y-%m-%d")} "Naco Taco" "Tacos for Dinner"
+Expenses:Food:Dining  10.00 USD""",
+        f"""{datetime.now().strftime("%Y-%m-%d")} "Sagar Ratna" "Dosa for Lunch"
+Expenses:Food:Dining  10.00 USD""",
+        f"""2020-04-01 "SuperMercado" "Bananas"
+Expenses:Food:Groceries  10.00 USD""",
+        f"""2020-01-01 "Naco Taco" "Burittos for Dinner"
+Expenses:Food:Dining  10.00 USD""",
+    ]
 
     # Act
     response = converse(
-        text=context,  # Assume context retrieved from notes for the user_query
+        references=context,  # Assume context retrieved from notes for the user_query
         user_query="What did I have for Dinner today?",
         api_key=api_key,
     )
@@ -334,23 +337,20 @@ def test_answer_requires_current_date_awareness():
 def test_answer_requires_date_aware_aggregation_across_provided_notes():
     "Chat actor should be able to answer questions that require date aware aggregation across multiple notes"
     # Arrange
-    context = f"""
-    # {datetime.now().strftime("%Y-%m-%d")} "Naco Taco" "Tacos for Dinner"
-      Expenses:Food:Dining  10.00 USD
-
-    # {datetime.now().strftime("%Y-%m-%d")} "Sagar Ratna" "Dosa for Lunch"
-      Expenses:Food:Dining  10.00 USD
-
-    # 2020-04-01 "SuperMercado" "Bananas"
-      Expenses:Food:Groceries  10.00 USD
-
-    # 2020-01-01 "Naco Taco" "Burittos for Dinner"
-      Expenses:Food:Dining  10.00 USD
-    """
+    context = [
+        f"""# {datetime.now().strftime("%Y-%m-%d")} "Naco Taco" "Tacos for Dinner"
+Expenses:Food:Dining  10.00 USD""",
+        f"""{datetime.now().strftime("%Y-%m-%d")} "Sagar Ratna" "Dosa for Lunch"
+Expenses:Food:Dining  10.00 USD""",
+        f"""2020-04-01 "SuperMercado" "Bananas"
+Expenses:Food:Groceries  10.00 USD""",
+        f"""2020-01-01 "Naco Taco" "Burittos for Dinner"
+Expenses:Food:Dining  10.00 USD""",
+    ]
 
     # Act
     response = converse(
-        text=context,  # Assume context retrieved from notes for the user_query
+        references=context,  # Assume context retrieved from notes for the user_query
         user_query="How much did I spend on dining this year?",
         api_key=api_key,
     )
@@ -366,14 +366,14 @@ def test_answer_general_question_not_in_chat_history_or_retrieved_content():
     "Chat actor should be able to answer general questions not requiring looking at chat history or notes"
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
-        ("Where was I born?", "You were born Testville.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
+        ("Where was I born?", "You were born Testville.", []),
     ]
 
     # Act
     response = converse(
-        text="",  # Assume no context retrieved from notes for the user_query
+        references=[],  # Assume no context retrieved from notes for the user_query
         user_query="Write a haiku about unit testing in 3 lines",
         conversation_log=populate_chat_history(message_list),
         api_key=api_key,
@@ -393,20 +393,18 @@ def test_answer_general_question_not_in_chat_history_or_retrieved_content():
 def test_ask_for_clarification_if_not_enough_context_in_question():
     "Chat actor should ask for clarification if question cannot be answered unambiguously with the provided context"
     # Arrange
-    context = f"""
-    # Ramya
-    My sister, Ramya, is married to Kali Devi. They have 2 kids, Ravi and Rani.
-
-    # Fang
-    My sister, Fang Liu is married to Xi Li. They have 1 kid, Xiao Li.
-
-    # Aiyla
-    My sister, Aiyla is married to Tolga. They have 3 kids, Yildiz, Ali and Ahmet.
-     """
+    context = [
+        f"""# Ramya
+My sister, Ramya, is married to Kali Devi. They have 2 kids, Ravi and Rani.""",
+        f"""# Fang
+My sister, Fang Liu is married to Xi Li. They have 1 kid, Xiao Li.""",
+        f"""# Aiyla
+My sister, Aiyla is married to Tolga. They have 3 kids, Yildiz, Ali and Ahmet.""",
+    ]
 
     # Act
     response = converse(
-        text=context,  # Assume context retrieved from notes for the user_query
+        references=context,  # Assume context retrieved from notes for the user_query
         user_query="How many kids does my older sister have?",
         api_key=api_key,
     )

--- a/tests/test_chat_director.py
+++ b/tests/test_chat_director.py
@@ -47,7 +47,7 @@ def test_chat_with_no_chat_history_or_retrieved_content(chat_client):
     expected_responses = ["Khoj", "khoj"]
     assert response.status_code == 200
     assert any([expected_response in response_message for expected_response in expected_responses]), (
-        "Expected assistants name, [K|k]hoj, in response but got" + response_message
+        "Expected assistants name, [K|k]hoj, in response but got: " + response_message
     )
 
 
@@ -69,7 +69,7 @@ def test_answer_from_chat_history(chat_client):
     expected_responses = ["Testatron", "testatron"]
     assert response.status_code == 200
     assert any([expected_response in response_message for expected_response in expected_responses]), (
-        "Expected [T|t]estatron in response but got" + response_message
+        "Expected [T|t]estatron in response but got: " + response_message
     )
 
 

--- a/tests/test_chat_director.py
+++ b/tests/test_chat_director.py
@@ -56,8 +56,8 @@ def test_chat_with_no_chat_history_or_retrieved_content(chat_client):
 def test_answer_from_chat_history(chat_client):
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
     ]
     populate_chat_history(message_list)
 
@@ -78,8 +78,12 @@ def test_answer_from_chat_history(chat_client):
 def test_answer_from_currently_retrieved_content(chat_client):
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", "Testatron was born on 1st April 1984 in Testville."),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        (
+            "When was I born?",
+            "You were born on 1st April 1984.",
+            ["Testatron was born on 1st April 1984 in Testville."],
+        ),
     ]
     populate_chat_history(message_list)
 
@@ -97,8 +101,12 @@ def test_answer_from_currently_retrieved_content(chat_client):
 def test_answer_from_chat_history_and_previously_retrieved_content(chat_client):
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", "Testatron was born on 1st April 1984 in Testville."),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        (
+            "When was I born?",
+            "You were born on 1st April 1984.",
+            ["Testatron was born on 1st April 1984 in Testville."],
+        ),
     ]
     populate_chat_history(message_list)
 
@@ -119,8 +127,8 @@ def test_answer_from_chat_history_and_previously_retrieved_content(chat_client):
 def test_answer_from_chat_history_and_currently_retrieved_content(chat_client):
     # Arrange
     message_list = [
-        ("Hello, my name is Xi Li. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
+        ("Hello, my name is Xi Li. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
     ]
     populate_chat_history(message_list)
 
@@ -143,8 +151,8 @@ def test_no_answer_in_chat_history_or_retrieved_content(chat_client):
     "Chat director should say don't know as not enough contexts in chat history or retrieved to answer question"
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
     ]
     populate_chat_history(message_list)
 
@@ -197,9 +205,9 @@ def test_answer_requires_date_aware_aggregation_across_provided_notes(chat_clien
 def test_answer_general_question_not_in_chat_history_or_retrieved_content(chat_client):
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
-        ("Where was I born?", "You were born Testville.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
+        ("Where was I born?", "You were born Testville.", []),
     ]
     populate_chat_history(message_list)
 
@@ -243,9 +251,9 @@ def test_ask_for_clarification_if_not_enough_context_in_question(chat_client):
 def test_answer_in_chat_history_beyond_lookback_window(chat_client):
     # Arrange
     message_list = [
-        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", ""),
-        ("When was I born?", "You were born on 1st April 1984.", ""),
-        ("Where was I born?", "You were born Testville.", ""),
+        ("Hello, my name is Testatron. Who are you?", "Hi, I am Khoj, a personal assistant. How can I help?", []),
+        ("When was I born?", "You were born on 1st April 1984.", []),
+        ("Where was I born?", "You were born Testville.", []),
     ]
     populate_chat_history(message_list)
 


### PR DESCRIPTION
### Khoj Chat on Emacs Improvements
- d78454d Load Khoj Chat buffer before asking for query to provide context
- 93e2aff Use org footnotes to add references, allows jump to def on click
- 5e9558d Stylize reference links as superscripts and show definition on hover
- bc71c19 Use `m` or `C-x m` in-buffer keybindings to send messages to Khoj

### Khoj Chat Server Improvements
- 27217a3 Time chat API sub-components for performance analysis
- 508b217 Update Chat API, Logs, Interfaces to store, use references as list
- d4b3866 Truncate message logs to below max supported prompt size by chat model
- cf28f10 Register separate timestamps for user query and response by Khoj Chat