### PR TITLE
Install, Start and Configure Search, Chat on Khoj Server from Emacs

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -248,6 +248,7 @@ for example), set this to the full interpreter path."
 
 (defun khoj--server-start ()
   "Start the khoj server."
+  (interactive)
   (let* ((url-parts (split-string (cadr (split-string khoj-server-url "://")) ":"))
          (server-host (nth 0 url-parts))
          (server-port (or (nth 1 url-parts) "80"))
@@ -288,6 +289,7 @@ for example), set this to the full interpreter path."
 
 (defun khoj--server-stop ()
   "Stop the khoj server."
+  (interactive)
   (when (khoj--server-running?)
     (message "khoj.el: Stopping server...")
     (kill-process khoj--server-process)
@@ -295,11 +297,13 @@ for example), set this to the full interpreter path."
 
 (defun khoj--server-restart ()
   "Restart the khoj server."
+  (interactive)
   (khoj--server-stop)
   (khoj--server-start))
 
 (defun khoj--server-setup ()
   "Install and start the khoj server, if required."
+  (interactive)
   ;; Install khoj server, if not available but expected on local machine
   (when (and is-khoj-server-local
              (or (not (executable-find khoj-server-command))
@@ -502,7 +506,6 @@ CONFIG is json obtained from Khoj config API."
   (let ((config-url (format "%s/api/config/types" khoj-server-url))
         (url-request-method "GET"))
     (with-temp-buffer
-      (erase-buffer)
       (url-insert-file-contents config-url)
       (thread-last
         (json-parse-buffer :object-type 'alist)
@@ -649,7 +652,6 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
          (encoded-query (url-hexify-string query))
          (query-url (format "%s/api/chat?q=%s" khoj-server-url encoded-query)))
     (with-temp-buffer
-      (erase-buffer)
       (url-insert-file-contents query-url)
       (json-parse-buffer :object-type 'alist))))
 
@@ -892,7 +894,7 @@ Paragraph only starts at first text after blank line."
   (interactive (list (transient-args transient-current-command)))
   (khoj--chat))
 
-(transient-define-prefix khoj-menu ()
+(transient-define-prefix khoj--menu ()
   "Create Khoj Menu to Configure and Execute Commands."
   [["Configure Search"
     ("n" "Results Count" "--results-count=" :init-value (lambda (obj) (oset obj value (format "%s" khoj-results-count))))
@@ -921,7 +923,7 @@ Paragraph only starts at first text after blank line."
     (khoj--server-setup))
   (while (not khoj--server-ready?)
     (sleep-for 0.5))
-  (khoj-menu))
+  (khoj--menu))
 
 (provide 'khoj)
 

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -65,7 +65,7 @@
   :group 'khoj
   :type 'string)
 
-(defcustom is-khoj-server-local t
+(defcustom khoj-server-is-local t
   "Is Khoj server on local machine?."
   :group 'khoj
   :type 'boolean)
@@ -185,13 +185,13 @@ Use `which-key` if available, else display simple message in echo area"
       (executable-find "khoj.exe")
       "khoj")
   "Command to interact with Khoj server."
-  :group 'khoj
-  :type 'string)
+  :type 'string
+  :group 'khoj)
 
 (defcustom khoj-server-args '("--no-gui")
   "Arguments to pass to Khoj server on startup."
-  :group 'khoj
-  :type '(repeat string))
+  :type '(repeat string)
+  :group 'khoj)
 
 (defcustom khoj-server-python-command
   (if (equal system-type 'windows-nt)
@@ -219,13 +219,13 @@ for example), set this to the full interpreter path."
 
 (defcustom khoj-org-files-index (org-agenda-files t t)
   "List of org-files to index on khoj server."
-  :group 'khoj
-  :type '(repeat string))
+  :type '(repeat string)
+  :group 'khoj)
 
 (defcustom khoj-openai-api-key nil
   "OpenAI API key used to configure chat on khoj server."
-  :group 'khoj
-  :type 'string)
+  :type 'string
+  :group 'khoj)
 
 (defvar khoj--server-process nil "Track Khoj server process.")
 (defvar khoj--server-name "*khoj-server*" "Track Khoj server buffer.")
@@ -326,7 +326,7 @@ for example), set this to the full interpreter path."
   "Install and start the khoj server, if required."
   (interactive)
   ;; Install khoj server, if not available but expected on local machine
-  (when (and is-khoj-server-local
+  (when (and khoj-server-is-local
              (or (not (executable-find khoj-server-command))
                  (not (khoj--server-get-version))))
       (khoj--server-install-upgrade))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -281,13 +281,14 @@ for example), set this to the full interpreter path."
 
 (defun khoj--server-running? ()
   "Check if the khoj server is running."
-  (or
-   ;; check for when server process handled from within emacs
-   (and khoj--server-process
-        (not (null (process-live-p khoj--server-process))))
-   ;; else general check via ping to khoj-server-url
-   (ignore-errors
-     (not (null (khoj--get-enabled-content-types) t)))))
+  (when (or
+       ;; check for when server process handled from within emacs
+       (and khoj--server-process
+            (not (null (process-live-p khoj--server-process))))
+       ;; else general check via ping to khoj-server-url
+       (ignore-errors
+         (not (null (url-retrieve-synchronously (format "%s/api/config/data/default" khoj-server-url))))))
+      (setq khoj--server-ready? t)))
 
 (defun khoj--server-stop ()
   "Stop the khoj server."

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -233,13 +233,13 @@ for example), set this to the full interpreter path."
   :group 'khoj)
 
 (defcustom khoj-auto-setup t
-  "Automate install, configure and starting khoj server.
+  "Automate install, configure and start of khoj server.
 Auto invokes setup steps on calling main entrypoint."
   :type 'string
   :group 'khoj)
 
-(defvar khoj--server-process nil "Track Khoj server process.")
-(defvar khoj--server-name "*khoj-server*" "Track Khoj server buffer.")
+(defvar khoj--server-process nil "Track khoj server process.")
+(defvar khoj--server-name "*khoj-server*" "Track khoj server buffer.")
 (defvar khoj--server-ready? nil "Track if khoj server is ready to receive API calls.")
 (defvar khoj--server-configured? t "Track if khoj server is configured to receive API calls.")
 (defvar khoj--progressbar '(🌑 🌘 🌗 🌖 🌕 🌔 🌓 🌒) "Track progress via moon phase animations.")
@@ -322,6 +322,12 @@ Auto invokes setup steps on calling main entrypoint."
         (setq khoj--server-ready? t)
       nil)))
 
+(defun khoj--server-restart ()
+  "Restart the khoj server."
+  (interactive)
+  (khoj--server-stop)
+  (khoj--server-start))
+
 (defun khoj--server-stop ()
   "Stop the khoj server."
   (interactive)
@@ -329,12 +335,6 @@ Auto invokes setup steps on calling main entrypoint."
     (message "khoj.el: Stopping server...")
     (kill-process khoj--server-process)
     (message "khoj.el: Stopped server.")))
-
-(defun khoj--server-restart ()
-  "Restart the khoj server."
-  (interactive)
-  (khoj--server-stop)
-  (khoj--server-start))
 
 (defun khoj--server-setup ()
   "Install and start the khoj server, if required."

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -218,9 +218,14 @@ for example), set this to the full interpreter path."
   :group 'khoj)
 
 (defcustom khoj-org-files-index (org-agenda-files t t)
-  "List of org-files to index on khoj server"
+  "List of org-files to index on khoj server."
   :group 'khoj
   :type '(repeat string))
+
+(defcustom khoj-openai-api-key nil
+  "OpenAI API key used to configure chat on khoj server."
+  :group 'khoj
+  :type 'string)
 
 (defvar khoj--server-process nil "Track Khoj server process.")
 (defvar khoj--server-name "*khoj-server*" "Track Khoj server buffer.")
@@ -328,7 +333,7 @@ CONFIG is json obtained from Khoj config API."
           (string-join "/"))))
 
 (defun khoj--server-configure ()
-  "Configure the khoj server to index specified files."
+  "Configure the the Khoj server for search and chat."
   (interactive)
   (let* ((current-config
           (with-temp-buffer
@@ -339,19 +344,21 @@ CONFIG is json obtained from Khoj config API."
              (url-insert-file-contents (format "%s/api/config/data/default" khoj-server-url))
              (ignore-error json-end-of-file (json-parse-buffer :object-type 'alist :array-type 'list :null-object json-null :false-object json-false))))
          (default-index-dir (khoj--get-directory-from-config default-config '(content-type org embeddings-file)))
+         (default-chat-dir (khoj--get-directory-from-config default-config '(processor conversation conversation-logfile)))
+         (default-model (or (alist-get 'model (alist-get 'conversation (alist-get 'processor default-config))) "text-davinci-003"))
          (config (or current-config default-config)))
+
+    ;; Configure content types
     (cond
      ;; If khoj backend is not configured yet
      ((not current-config)
       (setq config (delq (assoc 'content-type config) config))
-      (setq config (delq (assoc 'processor config) config))
-      (add-to-list 'config `(content-type . ((org . ((input-files . ,khoj-org-files-index)
-                                                     (input-filter . ,json-null)
-                                                     (compressed-jsonl . ,(format "%s/org.jsonl.gz" default-index-dir))
-                                                     (embeddings-file . ,(format "%s/org.pt" default-index-dir))
-                                                     (index-heading-entries . ,json-false))))))
-      (khoj--post-new-config config)
-      (message "khoj.el: ⚙️ Generated new khoj server configuration."))
+      (add-to-list 'config
+                   `(content-type . ((org . ((input-files . ,khoj-org-files-index)
+                                             (input-filter . ,json-null)
+                                             (compressed-jsonl . ,(format "%s/org.jsonl.gz" default-index-dir))
+                                             (embeddings-file . ,(format "%s/org.pt" default-index-dir))
+                                             (index-heading-entries . ,json-false)))))))
 
      ;; Else if khoj config has no org content config
      ((not (alist-get 'org (alist-get 'content-type config)))
@@ -363,11 +370,9 @@ CONFIG is json obtained from Khoj config API."
                                                 (embeddings-file . ,(format "%s/org.pt" default-index-dir))
                                                 (index-heading-entries . ,json-false))))
         (setq config (delq (assoc 'content-type config) config))
-        (add-to-list 'config `(content-type . ,new-content-type)))
-      (khoj--post-new-config config)
-      (message "Khoj: ⚙️ Added org content to index on khoj server."))
+        (add-to-list 'config `(content-type . ,new-content-type))))
 
-     ;; Else if khoj is not configured to index org files
+     ;; Else if khoj is not configured to index specified org files
      ((not (equal (alist-get 'input-files (alist-get 'org (alist-get 'content-type config))) khoj-org-files-index))
       (let* ((index-directory (khoj--get-directory-from-config config '(content-type org embeddings-file)))
              (new-content-type (alist-get 'content-type config)))
@@ -378,9 +383,47 @@ CONFIG is json obtained from Khoj config API."
                                                 (embeddings-file . ,(format "%s/org.pt" index-directory))
                                                 (index-heading-entries . ,json-false))))
         (setq config (delq (assoc 'content-type config) config))
-        (add-to-list 'config `(content-type . ,new-content-type)))
-      (khoj--post-new-config config)
-      (message "Khoj: ⚙️ Updated org content in index on khoj server")))))
+        (add-to-list 'config `(content-type . ,new-content-type)))))
+
+    ;; Configure processors
+    (cond
+     ((not khoj-openai-api-key)
+      (setq config (delq (assoc 'processor config) config)))
+
+     ((not current-config)
+      (setq config (delq (assoc 'processor config) config))
+      (add-to-list 'config
+                   `(processor . ((conversation . ((conversation-logfile . ,(format "%s/conversation.json" default-chat-dir))
+                                                   (model . ,default-model)
+                                                   (openai-api-key . ,khoj-openai-api-key)))))))
+
+     ((not (alist-get 'conversation (alist-get 'processor config)))
+       (let ((new-processor-type (alist-get 'processor config)))
+         (setq new-processor-type (delq (assoc 'conversation new-processor-type) new-processor-type))
+         (add-to-list 'new-processor-type `(conversation . ((conversation-logfile . ,(format "%s/conversation.json" default-chat-dir))
+                                                            (model . ,default-model)
+                                                            (openai-api-key . ,khoj-openai-api-key))))
+        (setq config (delq (assoc 'processor config) config))
+        (add-to-list 'config `(processor . ,new-processor-type))))
+
+     ;; Else if khoj is not configured with specified openai api key
+     ((not (equal (alist-get 'openai-api-key (alist-get 'conversation (alist-get 'processor config))) khoj-openai-api-key))
+      (let* ((chat-directory (khoj--get-directory-from-config config '(processor conversation conversation-logfile)))
+             (model-name (khoj--get-directory-from-config config '(processor conversation model)))
+             (new-processor-type (alist-get 'processor config)))
+        (setq new-processor-type (delq (assoc 'conversation new-processor-type) new-processor-type))
+        (add-to-list 'new-processor-type `(conversation . ((conversation-logfile . ,(format "%s/conversation.json" chat-directory))
+                                                           (model . ,model-name)
+                                                           (openai-api-key . ,khoj-openai-api-key))))
+        (setq config (delq (assoc 'processor config) config))
+        (add-to-list 'config `(processor . ,new-processor-type)))))
+
+     ;; Update server with latest configuration
+     (khoj--post-new-config config)
+     (cond ((not current-config)
+            (message "khoj.el: ⚙️ Generated new khoj server configuration."))
+           ((not (equal config current-config))
+            (message "Khoj: ⚙️ Updated khoj server configuration")))))
 
 
 ;; -----------------------------------------------

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -266,7 +266,9 @@ for example), set this to the full interpreter path."
                        (setq khoj--server-ready? nil))
            :filter (lambda (process msg)
                      (cond ((string-match (format "Uvicorn running on %s" khoj-server-url) msg)
-                            (setq khoj--server-ready? t))
+                            (progn
+                              (setq khoj--server-ready? t)
+                              (khoj--server-configure)))
                            ((not khoj--server-ready?)
                             (dolist (line (split-string msg "\n"))
                               (message "khoj.el: %s" (nth 1 (split-string msg "  " t " *"))))))
@@ -923,6 +925,7 @@ Paragraph only starts at first text after blank line."
     (khoj--server-setup))
   (while (not khoj--server-ready?)
     (sleep-for 0.5))
+  (khoj--server-configure)
   (khoj--menu))
 
 (provide 'khoj)

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -655,8 +655,14 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
          (encoded-query (url-hexify-string query))
          (query-url (format "%s/api/chat?q=%s" khoj-server-url encoded-query)))
     (with-temp-buffer
-      (url-insert-file-contents query-url)
-      (json-parse-buffer :object-type 'alist))))
+      (condition-case ex
+          (progn
+            (url-insert-file-contents query-url)
+            (json-parse-buffer :object-type 'alist))
+        ('file-error (cond ((string-match "Internal server error" (nth 2 ex))
+                      (message "Chat processor not configured. Configure OpenAI API key and restart it. Exception: [%s]" ex))
+                     (t (message "Chat exception: [%s]" ex))))))))
+
 
 (defun khoj--render-chat-message (message sender &optional receive-date)
   "Render chat messages as `org-mode' list item.

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -274,12 +274,14 @@ for example), set this to the full interpreter path."
                             (progn
                               (setq khoj--server-ready? t)
                               (khoj--server-configure)))
-                           ((not khoj--server-ready?)
+                           ((and (not khoj--server-ready?)
+                                 (or (string-match "configure.py" msg)
+                                     (string-match "main.py" msg)
+                                     (string-match "api.py" msg)))
                             (dolist (line (split-string msg "\n"))
                               (message "khoj.el: %s" (nth 1 (split-string msg "  " t " *"))))))
                      ;; call default process filter to write output to process buffer
-                     (internal-default-process-filter process msg))
-           ))
+                     (internal-default-process-filter process msg))))
     (set-process-query-on-exit-flag khoj--server-process nil)
     (when (not khoj--server-process)
         (message "khoj.el: Failed to start Khoj server. Please start it manually by running `khoj' on terminal.\n%s" (buffer-string)))))

--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -316,16 +316,16 @@ for example), set this to the full interpreter path."
   (when (not (khoj--server-running?))
     (khoj--server-start)))
 
-(defun khoj--get-content-index-dir (config type)
-  "Extract directory containing index files of specified content TYPE from CONFIG.
+(defun khoj--get-directory-from-config (config keys &optional level)
+  "Extract directory under specified KEYS in CONFIG and trim it to LEVEL.
 CONFIG is json obtained from Khoj config API."
-  (--> config
-       (cdr (assoc 'content-type it))
-       (cdr (assoc type it))
-       (cdr (assoc 'embeddings-file it))
-       (split-string it "/")
-       (butlast it)
-       (string-join it "/")))
+  (let ((item config))
+    (dolist (key keys)
+      (setq item (cdr (assoc key item))))
+      (-> item
+          (split-string "/")
+          (butlast (or level nil))
+          (string-join "/"))))
 
 (defun khoj--server-configure ()
   "Configure the khoj server to index specified files."
@@ -338,7 +338,7 @@ CONFIG is json obtained from Khoj config API."
            (with-temp-buffer
              (url-insert-file-contents (format "%s/api/config/data/default" khoj-server-url))
              (ignore-error json-end-of-file (json-parse-buffer :object-type 'alist :array-type 'list :null-object json-null :false-object json-false))))
-         (default-index-dir (khoj--get-content-index-dir default-config 'org))
+         (default-index-dir (khoj--get-directory-from-config default-config '(content-type org embeddings-file)))
          (config (or current-config default-config)))
     (cond
      ;; If khoj backend is not configured yet
@@ -369,7 +369,7 @@ CONFIG is json obtained from Khoj config API."
 
      ;; Else if khoj is not configured to index org files
      ((not (equal (alist-get 'input-files (alist-get 'org (alist-get 'content-type config))) khoj-org-files-index))
-      (let* ((index-directory (khoj--get-content-index-dir config 'org))
+      (let* ((index-directory (khoj--get-directory-from-config config '(content-type org embeddings-file)))
              (new-content-type (alist-get 'content-type config)))
         (setq new-content-type (delq (assoc 'org new-content-type) new-content-type))
         (add-to-list 'new-content-type `(org . ((input-files . ,khoj-org-files-index)

--- a/src/interface/emacs/tests/khoj-tests.el
+++ b/src/interface/emacs/tests/khoj-tests.el
@@ -109,8 +109,7 @@ Penance to Immortality\n\
 ** Act\n\
 \n\
 Rule everything\n\
-\n\
-#+STARTUP: showall hidestars inlineimages"))))
+\n"))))
 
 
 (ert-deftest khoj-tests--extract-entries-as-ledger ()

--- a/src/khoj/routers/api.py
+++ b/src/khoj/routers/api.py
@@ -33,6 +33,12 @@ def get_default_config_data():
 @api.get("/config/types", response_model=List[str])
 def get_config_types():
     """Get configured content types"""
+    if state.config is None or state.config.content_type is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Content types not configured. Configure at least one content type on server and restart it.",
+        )
+
     configured_content_types = state.config.content_type.dict(exclude_none=True)
     return [
         search_type.value
@@ -190,6 +196,15 @@ def update(t: Optional[SearchType] = None, force: Optional[bool] = False):
 
 @api.get("/chat")
 def chat(q: Optional[str] = None):
+    if (
+        state.processor_config is None
+        or state.processor_config.conversation is None
+        or state.processor_config.conversation.openai_api_key is None
+    ):
+        raise HTTPException(
+            status_code=500, detail="Chat processor not configured. Configure OpenAI API key on server and restart it."
+        )
+
     # Initialize Variables
     api_key = state.processor_config.conversation.openai_api_key
     model = state.processor_config.conversation.model

--- a/src/khoj/utils/constants.py
+++ b/src/khoj/utils/constants.py
@@ -56,6 +56,7 @@ default_config = {
     "processor": {
         "conversation": {
             "openai-api-key": None,
+            "model": "text-davinci-003",
             "conversation-logfile": "~/.khoj/processor/conversation/conversation_logs.json",
         }
     },


### PR DESCRIPTION
## Major Changes
- ae535a0 Configure Khoj chat using khoj.el by setting OpenAI API key in Emacs
- 82eb4bf Setup Khoj server on opening khoj.el
- 99d19dc Start Khoj server from Emacs using khoj.el
- c92d791 Install Khoj server from Emacs using khoj.el
  *This assumes you have python (<3.11) and pip installed in a system path*

### Sample Config
- Enable Khoj Chat by configuring you OpenAI API Key
- Specify Org Files, Directories to Index for Search (and Chat)
  By default, your org-agenda-files (include archive files)) are indexed
- Invoke khoj by calling `C-c s`

``` emacs-lisp
(use-package khoj
  :after org
  :straight (khoj
             :type git
             :host github
             :repo "debanjum/khoj"
             :files ("src/interface/emacs/khoj.el"))
  :bind ("C-c s" . 'khoj)
  :config (setq
           khoj-openai-api-key "<YOUR_OPENAI_API_KEY_FOR_KHOJ_CHAT>"
           khoj-org-directories '("~/docs/notes" "~/docs/journals")
           khoj-org-files '("~/docs/tasks.org" "~/docs/journal.org" "~/docs/archive.org")))
```