### PR TITLE
Use api_key keyword argument to set the openai_api_key parameter for GPT

### DIFF
--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -43,7 +43,7 @@ def completion_with_backoff(**kwargs):
     prompt = kwargs.pop("prompt")
     if "api_key" in kwargs:
         kwargs["openai_api_key"] = kwargs.get("api_key")
-    elif "openai_api_key" not in kwargs:
+    else:
         kwargs["openai_api_key"] = os.getenv("OPENAI_API_KEY")
     llm = OpenAI(**kwargs, request_timeout=10, max_retries=1)
     return llm(prompt)

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -41,7 +41,9 @@ max_prompt_size = {"gpt-3.5-turbo": 4096, "gpt-4": 8192}
 )
 def completion_with_backoff(**kwargs):
     prompt = kwargs.pop("prompt")
-    if "openai_api_key" not in kwargs:
+    if "api_key" in kwargs:
+        kwargs["openai_api_key"] = kwargs.get("api_key")
+    elif "openai_api_key" not in kwargs:
         kwargs["openai_api_key"] = os.getenv("OPENAI_API_KEY")
     llm = OpenAI(**kwargs, request_timeout=10, max_retries=1)
     return llm(prompt)


### PR DESCRIPTION
# Incoming
There's an assumption made in the `completion_with_backoff` method that the API key for GPT is passed in using `openai_api_key`, but most of the calling methods are using `api_key`. The code should still work if you're using an environment variable, but not if the key is passed only through the config.

Closes #220 