### PR TITLE
Pass truncated message as string in ChatMessage when exceeding max prompt size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,6 @@ dependencies = [
     "aiohttp == 3.8.4",
     "langchain >= 0.0.187",
     "pypdf >= 3.9.0",
-    "factory-boy==3.2.1",
-    "Faker==18.10.1"
 ]
 dynamic = ["version"]
 
@@ -80,6 +78,8 @@ dev = [
     "black >= 23.1.0",
     "pre-commit >= 3.0.4",
     "freezegun >= 1.2.0",
+    "factory-boy==3.2.1",
+    "Faker==18.10.1",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ dependencies = [
     "aiohttp == 3.8.4",
     "langchain >= 0.0.187",
     "pypdf >= 3.9.0",
+    "factory-boy==3.2.1",
+    "Faker==18.10.1"
 ]
 dynamic = ["version"]
 

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -98,10 +98,10 @@ def generate_chatml_messages_with_context(
 
     # Truncate oldest messages from conversation history until under max supported prompt size by model
     encoder = tiktoken.encoding_for_model(model_name)
-    tokens = sum([len(encoder.encode(content)) for message in messages for content in message.content])
+    tokens = sum([len(encoder.encode(message.content)) for message in messages])
     while tokens > max_prompt_size[model_name] and len(messages) > 1:
         messages.pop()
-        tokens = sum([len(encoder.encode(content)) for message in messages for content in message.content])
+        tokens = sum([len(encoder.encode(message.content)) for message in messages])
 
     # Truncate last message if still over max supported prompt size by model
     if tokens > max_prompt_size[model_name]:

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -97,13 +97,13 @@ def generate_chatml_messages_with_context(
     messages = user_chatml_message + rest_backnforths + system_chatml_message
 
     # Truncate oldest messages from conversation history until under max supported prompt size by model
-    messages = truncate_message(messages, max_prompt_size[model_name], model_name)
+    messages = truncate_messages(messages, max_prompt_size[model_name], model_name)
 
     # Return message in chronological order
     return messages[::-1]
 
 
-def truncate_message(messages, max_prompt_size, model_name):
+def truncate_messages(messages, max_prompt_size, model_name):
     """Truncate messages to fit within max prompt size supported by model"""
     encoder = tiktoken.encoding_for_model(model_name)
     tokens = sum([len(encoder.encode(message.content)) for message in messages])

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -106,7 +106,6 @@ def truncate_message(messages, max_prompt_size, model_name):
     """Truncate messages to fit within max prompt size supported by model"""
     encoder = tiktoken.encoding_for_model(model_name)
     tokens = sum([len(encoder.encode(message.content)) for message in messages])
-    logger.info(f"num tokens: {tokens}")
     while tokens > max_prompt_size and len(messages) > 1:
         messages.pop()
         tokens = sum([len(encoder.encode(message.content)) for message in messages])

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -110,7 +110,7 @@ def generate_chatml_messages_with_context(
         logger.debug(
             f"Truncate last message to fit within max prompt size of {max_prompt_size[model_name]} supported by {model_name} model:\n {truncated_message}"
         )
-        messages = [ChatMessage(content=[truncated_message], role=last_message.role)]
+        messages = [ChatMessage(content=truncated_message, role=last_message.role)]
 
     # Return message in chronological order
     return messages[::-1]

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -102,6 +102,7 @@ def generate_chatml_messages_with_context(
     # Return message in chronological order
     return messages[::-1]
 
+
 def truncate_message(messages, max_prompt_size, model_name):
     """Truncate messages to fit within max prompt size supported by model"""
     encoder = tiktoken.encoding_for_model(model_name)
@@ -112,8 +113,8 @@ def truncate_message(messages, max_prompt_size, model_name):
 
     # Truncate last message if still over max supported prompt size by model
     if tokens > max_prompt_size:
-        last_message = '\n'.join(messages[-1].content.split("\n")[:-1])
-        original_question = '\n'.join(messages[-1].content.split("\n")[-1:])
+        last_message = "\n".join(messages[-1].content.split("\n")[:-1])
+        original_question = "\n".join(messages[-1].content.split("\n")[-1:])
         original_question_tokens = len(encoder.encode(original_question))
         remaining_tokens = max_prompt_size - original_question_tokens
         truncated_message = encoder.decode(encoder.encode(last_message)[:remaining_tokens]).strip()

--- a/src/khoj/processor/conversation/utils.py
+++ b/src/khoj/processor/conversation/utils.py
@@ -45,7 +45,7 @@ def completion_with_backoff(**kwargs):
         kwargs["openai_api_key"] = kwargs.get("api_key")
     else:
         kwargs["openai_api_key"] = os.getenv("OPENAI_API_KEY")
-    llm = OpenAI(**kwargs, request_timeout=10, max_retries=1)
+    llm = OpenAI(**kwargs, request_timeout=20, max_retries=1)
     return llm(prompt)
 
 

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -1,11 +1,7 @@
 from khoj.processor.conversation import utils
 from langchain.schema import ChatMessage
 import factory
-import logging
 import tiktoken
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 class ChatMessageFactory(factory.Factory):
     class Meta:

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -1,0 +1,78 @@
+from khoj.processor.conversation import utils
+from langchain.schema import ChatMessage
+import factory
+import logging
+import tiktoken
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class ChatMessageFactory(factory.Factory):
+    class Meta:
+        model = ChatMessage
+
+    content = factory.Faker('paragraph')
+    role = factory.Faker('name')
+
+class TestTruncateMessage:
+    max_prompt_size = 4096
+    model_name = 'gpt-3.5-turbo'
+    encoder = tiktoken.encoding_for_model(model_name)
+
+    def test_truncate_message_all_small(self):
+        chat_messages = ChatMessageFactory.build_batch(500)
+        assert len(chat_messages) == 500
+        tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
+        assert tokens > self.max_prompt_size
+
+        prompt = utils.truncate_message(chat_messages, self.max_prompt_size, self.model_name)
+
+        # The original object has been modified. Verify certain properties
+        assert len(chat_messages) < 500
+        assert len(chat_messages) > 1
+        assert prompt == chat_messages
+
+        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
+        assert tokens <= self.max_prompt_size
+
+    def test_truncate_message_first_large(self):
+        chat_messages = ChatMessageFactory.build_batch(25)
+        big_chat_message = ChatMessageFactory.build(content=factory.Faker('paragraph', nb_sentences=1000))
+        big_chat_message.content = big_chat_message.content + "\n" + "Question?"
+        copy_big_chat_message = big_chat_message.copy()
+        chat_messages.insert(0, big_chat_message)
+        assert len(chat_messages) == 26
+        tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
+        assert tokens > self.max_prompt_size
+
+        prompt = utils.truncate_message(chat_messages, self.max_prompt_size, self.model_name)
+
+        # The original object has been modified. Verify certain properties
+        assert len(chat_messages) < 26
+        assert len(chat_messages) == 1
+        assert prompt[0] != copy_big_chat_message
+
+        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
+        assert tokens <= self.max_prompt_size
+
+    def test_truncate_message_last_large(self):
+        chat_messages = ChatMessageFactory.build_batch(25)
+        big_chat_message = ChatMessageFactory.build(content=factory.Faker('paragraph', nb_sentences=1000))
+        big_chat_message.content = big_chat_message.content + "\n" + "Question?"
+        copy_big_chat_message = big_chat_message.copy()
+        
+        chat_messages.append(big_chat_message)
+        assert len(chat_messages) == 26
+        tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
+        assert tokens > self.max_prompt_size
+
+        prompt = utils.truncate_message(chat_messages, self.max_prompt_size, self.model_name)
+
+        # The original object has been modified. Verify certain properties
+        assert len(chat_messages) < 26
+        assert len(chat_messages) > 1
+        assert prompt[0] != copy_big_chat_message
+
+        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
+        assert tokens < self.max_prompt_size
+    

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -3,16 +3,18 @@ from langchain.schema import ChatMessage
 import factory
 import tiktoken
 
+
 class ChatMessageFactory(factory.Factory):
     class Meta:
         model = ChatMessage
 
-    content = factory.Faker('paragraph')
-    role = factory.Faker('name')
+    content = factory.Faker("paragraph")
+    role = factory.Faker("name")
+
 
 class TestTruncateMessage:
     max_prompt_size = 4096
-    model_name = 'gpt-3.5-turbo'
+    model_name = "gpt-3.5-turbo"
     encoder = tiktoken.encoding_for_model(model_name)
 
     def test_truncate_message_all_small(self):
@@ -33,7 +35,7 @@ class TestTruncateMessage:
 
     def test_truncate_message_first_large(self):
         chat_messages = ChatMessageFactory.build_batch(25)
-        big_chat_message = ChatMessageFactory.build(content=factory.Faker('paragraph', nb_sentences=1000))
+        big_chat_message = ChatMessageFactory.build(content=factory.Faker("paragraph", nb_sentences=1000))
         big_chat_message.content = big_chat_message.content + "\n" + "Question?"
         copy_big_chat_message = big_chat_message.copy()
         chat_messages.insert(0, big_chat_message)
@@ -53,10 +55,10 @@ class TestTruncateMessage:
 
     def test_truncate_message_last_large(self):
         chat_messages = ChatMessageFactory.build_batch(25)
-        big_chat_message = ChatMessageFactory.build(content=factory.Faker('paragraph', nb_sentences=1000))
+        big_chat_message = ChatMessageFactory.build(content=factory.Faker("paragraph", nb_sentences=1000))
         big_chat_message.content = big_chat_message.content + "\n" + "Question?"
         copy_big_chat_message = big_chat_message.copy()
-        
+
         chat_messages.append(big_chat_message)
         assert len(chat_messages) == 26
         tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
@@ -71,4 +73,3 @@ class TestTruncateMessage:
 
         tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
         assert tokens < self.max_prompt_size
-    

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -19,18 +19,15 @@ class TestTruncateMessage:
 
     def test_truncate_message_all_small(self):
         chat_messages = ChatMessageFactory.build_batch(500)
-        assert len(chat_messages) == 500
         tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
-        assert tokens > self.max_prompt_size
 
-        prompt = utils.truncate_message(chat_messages, self.max_prompt_size, self.model_name)
+        prompt = utils.truncate_messages(chat_messages, self.max_prompt_size, self.model_name)
+        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
 
         # The original object has been modified. Verify certain properties
         assert len(chat_messages) < 500
         assert len(chat_messages) > 1
         assert prompt == chat_messages
-
-        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
         assert tokens <= self.max_prompt_size
 
     def test_truncate_message_first_large(self):
@@ -39,18 +36,14 @@ class TestTruncateMessage:
         big_chat_message.content = big_chat_message.content + "\n" + "Question?"
         copy_big_chat_message = big_chat_message.copy()
         chat_messages.insert(0, big_chat_message)
-        assert len(chat_messages) == 26
         tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
-        assert tokens > self.max_prompt_size
 
-        prompt = utils.truncate_message(chat_messages, self.max_prompt_size, self.model_name)
+        prompt = utils.truncate_messages(chat_messages, self.max_prompt_size, self.model_name)
+        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
 
         # The original object has been modified. Verify certain properties
-        assert len(chat_messages) < 26
         assert len(chat_messages) == 1
         assert prompt[0] != copy_big_chat_message
-
-        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
         assert tokens <= self.max_prompt_size
 
     def test_truncate_message_last_large(self):
@@ -60,16 +53,13 @@ class TestTruncateMessage:
         copy_big_chat_message = big_chat_message.copy()
 
         chat_messages.append(big_chat_message)
-        assert len(chat_messages) == 26
         tokens = sum([len(self.encoder.encode(message.content)) for message in chat_messages])
-        assert tokens > self.max_prompt_size
 
-        prompt = utils.truncate_message(chat_messages, self.max_prompt_size, self.model_name)
+        prompt = utils.truncate_messages(chat_messages, self.max_prompt_size, self.model_name)
+        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
 
         # The original object has been modified. Verify certain properties
         assert len(chat_messages) < 26
         assert len(chat_messages) > 1
         assert prompt[0] != copy_big_chat_message
-
-        tokens = sum([len(self.encoder.encode(message.content)) for message in prompt])
-        assert tokens < self.max_prompt_size
+        assert tokens <= self.max_prompt_size


### PR DESCRIPTION
# Incoming
Fix the way the `truncated_message` is passed to the `ChatMessage` object in the `/chat` flow. It expects a `string`, but it's currently passing the data in a `list`.

Closes #223 