### PR TITLE
Log clients calling API endpoints on Khoj server

### DIFF
--- a/src/interface/emacs/khoj.el
+++ b/src/interface/emacs/khoj.el
@@ -634,7 +634,7 @@ CONFIG is json obtained from Khoj config API."
       (buffer-string)))
   ;; Update index on khoj server after configuration update
   (let ((khoj--server-ready? nil))
-    (url-retrieve (format "%s/api/update?t=org" khoj-server-url) #'identity)))
+    (url-retrieve (format "%s/api/update?t=org&client=emacs" khoj-server-url) #'identity)))
 
 (defun khoj--get-enabled-content-types ()
   "Get content types enabled for search from API."
@@ -651,7 +651,7 @@ CONFIG is json obtained from Khoj config API."
 Use QUERY, CONTENT-TYPE and (optional) RERANK as query params"
   (let ((rerank (or rerank "false"))
         (encoded-query (url-hexify-string query)))
-    (format "%s/api/search?q=%s&t=%s&r=%s&n=%s" khoj-server-url encoded-query content-type rerank khoj-results-count)))
+    (format "%s/api/search?q=%s&t=%s&r=%s&n=%s&client=emacs" khoj-server-url encoded-query content-type rerank khoj-results-count)))
 
 (defun khoj--query-search-api-and-render-results (query-url content-type query buffer-name)
   "Query Khoj Search with QUERY-URL.
@@ -788,7 +788,7 @@ Render results in BUFFER-NAME using QUERY, CONTENT-TYPE."
   "Send QUERY to Khoj Chat API."
   (let* ((url-request-method "GET")
          (encoded-query (url-hexify-string query))
-         (query-url (format "%s/api/chat?q=%s" khoj-server-url encoded-query)))
+         (query-url (format "%s/api/chat?q=%s&client=emacs" khoj-server-url encoded-query)))
     (with-temp-buffer
       (condition-case ex
           (progn
@@ -1031,7 +1031,7 @@ Paragraph only starts at first text after blank line."
   (let* ((force-update (if (member "--force-update" args) "true" "false"))
          ;; set content type to: specified > last used > based on current buffer > default type
          (content-type (or (transient-arg-value "--content-type=" args) (khoj--buffer-name-to-content-type (buffer-name))))
-         (update-url (format "%s/api/update?t=%s&force=%s" khoj-server-url content-type force-update))
+         (update-url (format "%s/api/update?t=%s&force=%s&client=emacs" khoj-server-url content-type force-update))
          (url-request-method "GET"))
     (progn
       (setq khoj--content-type content-type)

--- a/src/interface/obsidian/src/chat_modal.ts
+++ b/src/interface/obsidian/src/chat_modal.ts
@@ -35,7 +35,7 @@ export class KhojChatModal extends Modal {
         contentEl.createDiv({ attr: { id: "khoj-chat-body", class: "khoj-chat-body" } });
 
         // Get conversation history from Khoj backend
-        let chatUrl = `${this.setting.khojUrl}/api/chat?`;
+        let chatUrl = `${this.setting.khojUrl}/api/chat?client=obsidian`;
         let response = await request(chatUrl);
         let chatLogs = JSON.parse(response).response;
         chatLogs.forEach((chatLog: any) => {
@@ -120,7 +120,7 @@ export class KhojChatModal extends Modal {
 
         // Get chat response from Khoj backend
         let encodedQuery = encodeURIComponent(query);
-        let chatUrl = `${this.setting.khojUrl}/api/chat?q=${encodedQuery}`;
+        let chatUrl = `${this.setting.khojUrl}/api/chat?q=${encodedQuery}&client=obsidian`;
         let response = await request(chatUrl);
         let data = JSON.parse(response);
 

--- a/src/interface/obsidian/src/search_modal.ts
+++ b/src/interface/obsidian/src/search_modal.ts
@@ -89,7 +89,7 @@ export class KhojSearchModal extends SuggestModal<SearchResult> {
     async getSuggestions(query: string): Promise<SearchResult[]> {
         // Query Khoj backend for search results
         let encodedQuery = encodeURIComponent(query);
-        let searchUrl = `${this.setting.khojUrl}/api/search?q=${encodedQuery}&n=${this.setting.resultsCount}&r=${this.rerank}`;
+        let searchUrl = `${this.setting.khojUrl}/api/search?q=${encodedQuery}&n=${this.setting.resultsCount}&r=${this.rerank}&client=obsidian`;
 
         // Get search results for markdown and pdf files
         let mdResponse = await request(`${searchUrl}&t=markdown`);

--- a/src/interface/obsidian/src/settings.ts
+++ b/src/interface/obsidian/src/settings.ts
@@ -107,8 +107,8 @@ export class KhojSettingTab extends PluginSettingTab {
                     }, 300);
                     this.plugin.registerInterval(progress_indicator);
 
-                    await request(`${this.plugin.settings.khojUrl}/api/update?t=markdown&force=true`);
-                    await request(`${this.plugin.settings.khojUrl}/api/update?t=pdf&force=true`);
+                    await request(`${this.plugin.settings.khojUrl}/api/update?t=markdown&force=true&client=obsidian`);
+                    await request(`${this.plugin.settings.khojUrl}/api/update?t=pdf&force=true&client=obsidian`);
                     new Notice('✅ Updated Khoj index.');
 
                     // Reset button once index is updated

--- a/src/khoj/interface/web/assets/config.js
+++ b/src/khoj/interface/web/assets/config.js
@@ -46,7 +46,7 @@ regenerateButton.addEventListener("click", (event) => {
     event.preventDefault();
     regenerateButton.style.cursor = "progress";
     regenerateButton.disabled = true;
-    fetch("/api/update?force=true")
+    fetch("/api/update?force=true&client=web")
         .then(response => response.json())
         .then(data => {
             regenerateButton.style.cursor = "pointer";

--- a/src/khoj/interface/web/chat.html
+++ b/src/khoj/interface/web/chat.html
@@ -62,7 +62,7 @@
             document.getElementById("chat-input").value = "";
 
             // Generate backend API URL to execute query
-            let url = `/api/chat?q=${encodeURIComponent(query)}`;
+            let url = `/api/chat?q=${encodeURIComponent(query)}&client=web`;
 
             // Call specified Khoj API
             fetch(url)
@@ -82,7 +82,7 @@
         }
 
         window.onload = function () {
-            fetch('/api/chat')
+            fetch('/api/chat?client=web')
                 .then(response => response.json())
                 .then(data => data.response)
                 .then(chat_logs => {

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -90,8 +90,8 @@
 
             // Generate Backend API URL to execute Search
             url = type === "image"
-                ? `/api/search?q=${encodeURIComponent(query)}&t=${type}&n=${results_count}`
-                : `/api/search?q=${encodeURIComponent(query)}&t=${type}&n=${results_count}&r=${rerank}`;
+                ? `/api/search?q=${encodeURIComponent(query)}&t=${type}&n=${results_count}&client=web`
+                : `/api/search?q=${encodeURIComponent(query)}&t=${type}&n=${results_count}&r=${rerank}&client=web`;
 
             // Execute Search and Render Results
             fetch(url)
@@ -107,7 +107,7 @@
 
         function updateIndex() {
             type = document.getElementById("type").value;
-            fetch(`/api/update?t=${type}`)
+            fetch(`/api/update?t=${type}&client=web`)
                 .then(response => response.json())
                 .then(data => {
                     console.log(data);

--- a/src/khoj/utils/helpers.py
+++ b/src/khoj/utils/helpers.py
@@ -3,11 +3,11 @@ from __future__ import annotations  # to avoid quoting type hints
 from collections import OrderedDict
 import datetime
 from importlib import import_module
+from importlib.metadata import version
 import logging
 from os import path
 from pathlib import Path
 import platform
-import requests
 import sys
 from time import perf_counter
 import torch
@@ -184,6 +184,7 @@ def log_telemetry(telemetry_type: str, api: str = None, client: str = None, app_
     request_body = {
         "telemetry_type": telemetry_type,
         "server_id": get_server_id(),
+        "server_version": version("khoj-assistant"),
         "os": platform.system(),
         "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }


### PR DESCRIPTION
- Make API endpoints on Khoj server accept `client` as request parameter
  - Khoj API endpoints: /chat, /search, /update
- Make Khoj clients set `client` request param when calling the API endpoints on the Khoj server
  - Khoj clients: Emacs, Obsidian and Web