### PR TITLE
Use Github REST API and Index Commit Messages off Github Repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "aiohttp == 3.8.4",
     "langchain >= 0.0.187",
     "pypdf >= 3.9.0",
-    "llama-hub==0.0.3",
+    "requests >= 2.26.0",
 ]
 dynamic = ["version"]
 

--- a/src/khoj/interface/web/index.html
+++ b/src/khoj/interface/web/index.html
@@ -34,6 +34,9 @@
         function render_markdown(query, data) {
             var md = window.markdownit();
             return md.render(data.map(function (item) {
+                lines = item.entry.split("\n")
+                if (item.additional.file.startsWith("http"))
+                    return `${lines[0]}\t[*](${item.additional.file})\n${lines.slice(1).join("\n")}`
                 return `${item.entry}`
             }).join("\n"));
         }

--- a/src/khoj/processor/github/github_to_jsonl.py
+++ b/src/khoj/processor/github/github_to_jsonl.py
@@ -77,12 +77,9 @@ class GithubToJsonl(TextToJsonl):
         return entries_with_ids
 
     def get_markdown_files(self):
-        # set the url to get the contents of the repository
+        # Get the contents of the repository
         repo_content_url = f"{self.repo_url}/git/trees/{self.config.repo_branch}"
-        # set the headers to include the authentication token
-        headers = {"Authorization": f"{self.config.pat_token}"}
-
-        # get the contents of the repository
+        headers = {"Authorization": f"token {self.config.pat_token}"}
         response = requests.get(repo_content_url, headers=headers)
         contents = response.json()
 
@@ -91,6 +88,7 @@ class GithubToJsonl(TextToJsonl):
         if result is not None:
             return result
 
+        # Extract markdown files from the repository
         markdown_files = []
         for item in contents["tree"]:
             # Find all markdown files in the repository
@@ -105,7 +103,7 @@ class GithubToJsonl(TextToJsonl):
 
     def get_file_contents(self, file_url):
         # Get text from each markdown file
-        headers = {"Authorization": f"{self.config.pat_token}", "Accept": "application/vnd.github.v3.raw"}
+        headers = {"Authorization": f"token {self.config.pat_token}", "Accept": "application/vnd.github.v3.raw"}
         response = requests.get(file_url, headers=headers)
 
         # Wait for rate limit reset if needed
@@ -117,8 +115,8 @@ class GithubToJsonl(TextToJsonl):
 
     def get_commits(self) -> List[Dict]:
         # Get commit messages from the repository using the Github API
-        headers = {"Authorization": f"{self.config.pat_token}"}
         commits_url = f"{self.repo_url}/commits"
+        headers = {"Authorization": f"token {self.config.pat_token}"}
         commits = []
 
         while commits_url is not None:

--- a/src/khoj/processor/github/github_to_jsonl.py
+++ b/src/khoj/processor/github/github_to_jsonl.py
@@ -87,11 +87,16 @@ class GithubToJsonl(TextToJsonl):
         for item in contents["tree"]:
             # Find all markdown files in the repository
             if item["type"] == "blob" and item["path"].endswith(".md"):
+                # Create URL for each markdown file on Github
+                url_path = f'https://github.com/{self.config.repo_owner}/{self.config.repo_name}/blob/{self.config.repo_branch}/{item["path"]}'
+
                 # Get text from each markdown file
                 file_content_url = f'{self.repo_url}/contents/{item["path"]}'
                 headers["Accept"] = "application/vnd.github.v3.raw"
                 markdown_file_contents = requests.get(file_content_url, headers=headers).content.decode("utf-8")
-                markdown_files += [{"content": markdown_file_contents, "path": item["path"]}]
+
+                # Add markdown file contents and URL to list
+                markdown_files += [{"content": markdown_file_contents, "path": url_path}]
 
         return markdown_files
 

--- a/src/khoj/processor/github/github_to_jsonl.py
+++ b/src/khoj/processor/github/github_to_jsonl.py
@@ -38,10 +38,10 @@ class GithubToJsonl(TextToJsonl):
             try:
                 docs = self.get_markdown_files()
             except Exception as e:
-                logger.error(f"Unable to download github repo for {self.config.repo_owner}/{self.config.repo_name}")
+                logger.error(f"Unable to download github repo {self.config.repo_owner}/{self.config.repo_name}")
                 raise e
 
-        logger.info(f"Found {len(docs)} documents in {self.config.repo_owner}/{self.config.repo_name}")
+        logger.info(f"Found {len(docs)} documents in github repo {self.config.repo_owner}/{self.config.repo_name}")
 
         with timer("Extract markdown entries from github repo", logger):
             current_entries = MarkdownToJsonl.convert_markdown_entries_to_maps(
@@ -63,7 +63,7 @@ class GithubToJsonl(TextToJsonl):
                     current_entries, previous_entries, key="compiled", logger=logger
                 )
 
-        with timer("Write markdown entries to JSONL file", logger):
+        with timer("Write github entries to JSONL file", logger):
             # Process Each Entry from All Notes Files
             entries = list(map(lambda entry: entry[1], entries_with_ids))
             jsonl_data = MarkdownToJsonl.convert_markdown_maps_to_jsonl(entries)
@@ -80,7 +80,8 @@ class GithubToJsonl(TextToJsonl):
         # Get the contents of the repository
         repo_content_url = f"{self.repo_url}/git/trees/{self.config.repo_branch}"
         headers = {"Authorization": f"token {self.config.pat_token}"}
-        response = requests.get(repo_content_url, headers=headers)
+        params = {"recursive": "true"}
+        response = requests.get(repo_content_url, headers=headers, params=params)
         contents = response.json()
 
         # Wait for rate limit reset if needed

--- a/src/khoj/processor/github/github_to_jsonl.py
+++ b/src/khoj/processor/github/github_to_jsonl.py
@@ -117,11 +117,12 @@ class GithubToJsonl(TextToJsonl):
         # Get commit messages from the repository using the Github API
         commits_url = f"{self.repo_url}/commits"
         headers = {"Authorization": f"token {self.config.pat_token}"}
+        params = {"per_page": 100}
         commits = []
 
         while commits_url is not None:
             # Get the next page of commits
-            response = requests.get(commits_url, headers=headers)
+            response = requests.get(commits_url, headers=headers, params=params)
             raw_commits = response.json()
 
             # Wait for rate limit reset if needed


### PR DESCRIPTION
- [X] Migrate to Github REST API instead of Llama Hub to index Markdown Docs in Repository
- [X] Index Commit Messages from Github Repository as well